### PR TITLE
Resolve failing Firebase tests

### DIFF
--- a/tests/test.ts
+++ b/tests/test.ts
@@ -11,15 +11,14 @@ import DbTestProvider from "../backend_tools/test_db_provider"
 
 const provider = new DbTestProvider()
 
-//test to create a user
-describe("This is to create a club on firebase", () => {
+//Test to create an organization
+describe("This is to create a club on Firebase", () => {
     it("should create a new club", (done) => {
 
+        const club: Club = { name: "Nebula Labs", description: "Computer science club at UTD", contacts: { email: "deadmail@deadmail.com" } }
 
-        const club: Club = { name: "ACM", description: "Computer science club at UTD", contacts: { email: "deadmail@deadmail.com" } }
-
-        const answer = provider.createClub(club).then(val => {
-            assert.isTrue(val)
+        const answer = provider.createClub(club).then(orgName => {
+            assert.isDefined(orgName)
             done()
         })
 
@@ -28,7 +27,7 @@ describe("This is to create a club on firebase", () => {
 
     it("Should delete the created club", (done) => {
 
-        provider.deleteClub("ACM").then(val => {
+        provider.deleteClub("Nebula Labs").then(val => {
             assert.isTrue(val)
             done()
         })
@@ -36,7 +35,7 @@ describe("This is to create a club on firebase", () => {
 
 })
 
-describe("This is to create a user on firebase", () => {
+describe("This is to create a user on Firebase", () => {
     it("should create a new user", (done) => {
 
         provider
@@ -51,20 +50,20 @@ describe("This is to create a user on firebase", () => {
 
         }
         const answer = provider.createUser(user).then(val => {
-            assert.isTrue(val)
+            assert.isDefined(val)
             done()
         })
     })
 }).timeout(5000)
 
-describe("This is to query for the club `Nebula`", () => {
-    it("Should retrieve the nebula object in the databaase", done => {
+describe("This is to query for the club `Nebula (Test)`", () => {
+    it("Should retrieve the Nebula object in the databaase", done => {
 
-        const club = provider.getClubsByName("Nebula")
+        const club = provider.getClubsByName("Nebula (Test)")
         club.then(val => {
             //need a way to get the club object from the db
 
-            assert.equal(val[0].name, "Nebula")
+            assert.equal(val[0].name, "Nebula (Test)")
             done()
         })
     })

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -20,8 +20,7 @@ describe("This is to create a club on Firebase", () => {
         const answer = provider.createClub(club).then(orgName => {
             assert.isDefined(orgName)
             done()
-        })
-
+        }).catch(done);
 
     }).timeout(5000)
 
@@ -30,7 +29,7 @@ describe("This is to create a club on Firebase", () => {
         provider.deleteClub("Nebula Labs").then(val => {
             assert.isTrue(val)
             done()
-        })
+        }).catch(done);
     }).timeout(3000)
 
 })
@@ -38,7 +37,6 @@ describe("This is to create a club on Firebase", () => {
 describe("This is to create a user on Firebase", () => {
     it("should create a new user", (done) => {
 
-        provider
         const user: User = {
             first_name: "Michael",
             last_name: "Bee",
@@ -52,12 +50,12 @@ describe("This is to create a user on Firebase", () => {
         const answer = provider.createUser(user).then(val => {
             assert.isDefined(val)
             done()
-        })
+        }).catch(done);
     })
 }).timeout(5000)
 
 describe("This is to query for the club `Nebula (Test)`", () => {
-    it("Should retrieve the Nebula object in the databaase", done => {
+    it("Should retrieve the Nebula object in the databaase", (done) => {
 
         const club = provider.getClubsByName("Nebula (Test)")
         club.then(val => {
@@ -65,7 +63,7 @@ describe("This is to query for the club `Nebula (Test)`", () => {
 
             assert.equal(val[0].name, "Nebula (Test)")
             done()
-        })
+        }).catch(done);
     })
 }).timeout(5000)
 


### PR DESCRIPTION
This PR revises the Firebase tests to ensure they pass. For this issue I verified that each method actually performs the expected function on the database.

For most cases, it appears that the tests needed to check for whether a defined value was returned after making a call to the database manager, where it was actually checking if the value was true.

There is an issue where mocha doesn't exit even after the tests are done. That may be something to address in a separate change.