### PR TITLE
Fix: Make club titles display 2 lines (#338)

### DIFF
--- a/src/components/club/ClubCard.tsx
+++ b/src/components/club/ClubCard.tsx
@@ -12,8 +12,7 @@ const ClubCard: FC<Props> = ({ club, session, priority }) => {
     club.description.length > 50
       ? club.description.slice(0, 150) + '...'
       : club.description;
-  const name =
-    club.name.length > 20 ? club.name.slice(0, 30) + '...' : club.name;
+  const name = club?.name ?? '';
   const placeholderImage =
     'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/2wBDAQMDAwQDBAgEBAgQCwkLEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBD/wAARCAAQABADAREAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAABgf/xAAXEAEAAwAAAAAAAAAAAAAAAAAFACIx/8QAGAEAAgMAAAAAAAAAAAAAAAAABAUGBwj/xAAWEQADAAAAAAAAAAAAAAAAAAAAAgT/2gAMAwEAAhEDEQA/ALuYnlpkZHL4onFpieWhaOI6JySlqZaKEcnNMwtMTy0MRxFROf/Z';
   return (
@@ -35,7 +34,7 @@ const ClubCard: FC<Props> = ({ club, session, priority }) => {
         )}
       </div>
       <div className="flex flex-col space-y-2 p-6">
-        <h1 className="line-clamp-1 text-2xl font-medium text-slate-800 md:text-xl">
+        <h1 className="line-clamp-2 text-2xl font-medium text-slate-800 md:text-xl">
           {name}
         </h1>
         <p className="text-sm text-slate-500 md:text-xs">Description</p>


### PR DESCRIPTION
### Context
Organization names were cut off after one line.

### Changes
- Updated `line-clamp-1` → `line-clamp-2` for two-line display  
- Removed manual name truncation logic

### Preview

Before
<img width="1917" height="862" alt="Club titles before" src="https://github.com/user-attachments/assets/b1b28ea8-6930-4e35-89ff-61484fddf6fa" />

After
<img width="1031" height="579" alt="Club titles after" src="https://github.com/user-attachments/assets/b213a029-80d7-4f65-bf62-fcb6e7615d47" />
