### PR TITLE
fix: update landing gradient start color to gray (#edeff2) (#345)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -67,7 +67,7 @@ const Home = async () => {
                 className="absolute bottom-[35%] left-[7%] w-[clamp(70px,20vw,150px)] animate-spin bg-no-repeat object-cover [animation-duration:60s]"
               />
             </section>
-            <section className="absolute top-[100vh] z-10 h-[20vh] w-screen bg-linear-to-t from-white to-transparent"></section>
+            <section className="absolute top-[100vh] z-10 h-[20vh] w-screen bg-linear-to-t from-[#edeff2] to-transparent"></section>
           </div>
         </div>
         <div className="relative inset-0 z-20 bg-transparent">


### PR DESCRIPTION
### Context
Landing gradient started with white instead of the gray page background.

### Changes
- Adjusted gradient start color to `#edeff2`

### Preview

Before
<img width="1421" height="730" alt="Before" src="https://github.com/user-attachments/assets/675ef786-6c2f-44ec-90ec-0524e041f397" />

After
<img width="1421" height="730" alt="After" src="https://github.com/user-attachments/assets/71572c31-b506-4683-975b-fe0e914db1cf" />
