### PR TITLE
fix: add pointer cursor to buttons (#336)

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -58,6 +58,10 @@
     text-decoration: none;
   }
 
+  button {
+    cursor: pointer;
+  }
+
   * {
     box-sizing: border-box;
   }


### PR DESCRIPTION
### Context
Buttons didn’t show a pointer cursor on hover.

### Changes
- Added `cursor: pointer;` style to all `<button>` elements in `globals.css`.

### Preview
| Before | After |
|:------:|:-----:|
|<img width="402" height="98" alt="Before 1" src="https://github.com/user-attachments/assets/28434e40-5906-4cc8-9aa4-c2881c1a254c" />|<img width="402" height="98" alt="After 1" src="https://github.com/user-attachments/assets/54b874d2-768f-487e-8bb4-6b5765515957" />|
|<img width="314" height="283" alt="Before 2" src="https://github.com/user-attachments/assets/4598d999-8f92-4c68-bdae-6076036bd62a" />|<img width="314" height="283" alt="After 2" src="https://github.com/user-attachments/assets/786eb5c2-39dc-46b2-8a08-4e5258220927" />|
|<img width="524" height="331" alt="Before 3" src="https://github.com/user-attachments/assets/d1b20a92-3bdd-434b-b946-b19b33bf43b5" />|<img width="524" height="331" alt="After 3" src="https://github.com/user-attachments/assets/79c90d14-1688-462e-864f-12517911fc62" />|


