### PR TITLE
feat(ui): make ClubCard fully clickable and remove Learn More button

### DIFF
--- a/src/components/club/ClubCard.tsx
+++ b/src/components/club/ClubCard.tsx
@@ -15,40 +15,41 @@ const ClubCard: FC<Props> = ({ club, session, priority }) => {
   const name = club?.name ?? '';
   const placeholderImage =
     'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/2wBDAQMDAwQDBAgEBAgQCwkLEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBD/wAARCAAQABADAREAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAABgf/xAAXEAEAAwAAAAAAAAAAAAAAAAAFACIx/8QAGAEAAgMAAAAAAAAAAAAAAAAABAUGBwj/xAAWEQADAAAAAAAAAAAAAAAAAAAAAgT/2gAMAwEAAhEDEQA/ALuYnlpkZHL4onFpieWhaOI6JySlqZaKEcnNMwtMTy0MRxFROf/Z';
+
   return (
-    <div className="flex h-full min-h-[400px] max-w-xs min-w-[300px] flex-col justify-between rounded-lg bg-white shadow-2xl md:min-h-[600px]">
-      <div className="relative h-48 overflow-hidden rounded-t-lg sm:h-56 md:h-64 lg:h-72">
-        {club.profileImage ? (
-          <Image
-            src={club.profileImage}
-            fill
-            alt={club.name + ' logo'}
-            priority={priority}
-            sizes="20rem"
-            className="object-cover select-none"
-            placeholder="blur"
-            blurDataURL={placeholderImage}
-          />
-        ) : (
-          <div className="absolute inset-0 h-full w-full bg-gray-200" />
-        )}
+    <Link href={`/directory/${club.slug}`} className="block group">
+      <div className="flex h-full min-h-[400px] max-w-xs min-w-[300px] flex-col justify-between rounded-lg bg-white shadow-2xl md:min-h-[600px]">
+        <div className="relative h-48 overflow-hidden rounded-t-lg sm:h-56 md:h-64 lg:h-72">
+          {club.profileImage ? (
+            <Image
+              src={club.profileImage}
+              fill
+              alt={club.name + ' logo'}
+              priority={priority}
+              sizes="20rem"
+              className="object-cover select-none"
+              placeholder="blur"
+              blurDataURL={placeholderImage}
+            />
+          ) : (
+            <div className="absolute inset-0 h-full w-full bg-gray-200" />
+          )}
+        </div>
+
+        <div className="flex flex-col space-y-2 p-6">
+          <h1 className="line-clamp-2 text-2xl font-medium text-slate-800 md:text-xl">
+            {name}
+          </h1>
+          <p className="text-base text-slate-600 md:text-sm">{desc}</p>
+        </div>
+
+        <div className="m-5 mt-auto flex flex-row space-x-2">
+          <div onClick={(e) => e.stopPropagation()}>
+            <JoinButton session={session} clubID={club.id} />
+          </div>
+        </div>
       </div>
-      <div className="flex flex-col space-y-2 p-6">
-        <h1 className="line-clamp-2 text-2xl font-medium text-slate-800 md:text-xl">
-          {name}
-        </h1>
-        <p className="text-base text-slate-600 md:text-sm">{desc}</p>
-      </div>
-      <div className="m-5 mt-auto flex flex-row space-x-2">
-        <JoinButton session={session} clubID={club.id} />
-        <Link
-          href={`/directory/${club.slug}`}
-          className="text-blue-primary rounded-2xl bg-blue-600/10 px-4 py-2 text-xs font-extrabold transition-colors hover:bg-blue-200"
-        >
-          Learn More
-        </Link>
-      </div>
-    </div>
+    </Link>
   );
 };
 


### PR DESCRIPTION
### Context
Only the Learn More button was clickable. 
Making the entire card clickable provides a better UX.

### Changes
- Made the entire `ClubCard` clickable to navigate to the detail page
- Removed “Learn More” button

### Preview
| Before | After |
|--------|--------|
|<img width="293" height="514" alt="Before" src="https://github.com/user-attachments/assets/c3e5bd7c-08df-47c8-a0a9-3de2d5ab844f" />|<img width="293" height="514" alt="After" src="https://github.com/user-attachments/assets/4aeece00-d2b6-4f7e-b001-c18dff0177ad" />|