### PR TITLE
Update responsive sizing for Homepage Searchbar

### DIFF
--- a/src/components/searchBar/HomePageSearch.tsx
+++ b/src/components/searchBar/HomePageSearch.tsx
@@ -52,7 +52,7 @@ export const HomePageSearchBar = () => {
     <>
       <div
         ref={containerRef}
-        className={`drop-shadow-[0_0_4px_rgb(0_0_0_/_0.4)] pt-6 w-full max-w-xs transition-all md:max-w-sm lg:max-w-md ${
+        className={`drop-shadow-[0_0_4px_rgb(0_0_0_/_0.4)] pt-6 w-full max-w-52 transition-all sm:max-w-[300px] md:max-w-sm lg:max-w-md ${
           isSticky ? 'fixed top-0 z-50 justify-center' : 'relative'
         }`}
       >


### PR DESCRIPTION
Resolves #352 
Updates the sizing for HomePageSearch so that it fits properly on small screen widths. 

Before:
<img width="400" height="108" alt="image" src="https://github.com/user-attachments/assets/eaef4411-3d6d-4931-9915-7d9bcc773a89" />

After:
<img width="400" height="108" alt="image" src="https://github.com/user-attachments/assets/77ee5e8d-4672-47aa-8acb-0fde678666ea" />