### PR TITLE
feat(clubcard): add heart button with white icon

### DIFF
--- a/src/components/club/ClubCard.tsx
+++ b/src/components/club/ClubCard.tsx
@@ -1,13 +1,22 @@
+import { Favorite, FavoriteBorder } from '@mui/icons-material';
 import { type Session } from 'next-auth';
 import Image from 'next/image';
 import Link from 'next/link';
-import { type FC } from 'react';
+import { useState, type FC } from 'react';
 import type { SelectClub as Club } from '@src/server/db/models';
 import JoinButton from './JoinButton';
 
 type Props = { club: Club; session: Session | null; priority: boolean };
 
 const ClubCard: FC<Props> = ({ club, session, priority }) => {
+  const [liked, setLiked] = useState(false);
+
+  const toggleLike = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    e.preventDefault();
+    setLiked(!liked);
+  };
+
   const desc =
     club.description.length > 50
       ? club.description.slice(0, 150) + '...'
@@ -20,6 +29,29 @@ const ClubCard: FC<Props> = ({ club, session, priority }) => {
     <Link href={`/directory/${club.slug}`} className="block group">
       <div className="flex h-full min-h-[400px] max-w-xs min-w-[300px] flex-col justify-between rounded-lg bg-white shadow-2xl md:min-h-[600px]">
         <div className="relative h-48 overflow-hidden rounded-t-lg sm:h-56 md:h-64 lg:h-72">
+          <button
+            onClick={toggleLike}
+            className="absolute top-3 right-3 z-10 p-2 transition hover:scale-105 active:scale-115"
+          >
+            {liked ? (
+              <Favorite
+                sx={{
+                  color: 'white',
+                  fontSize: 26,
+                  filter: 'drop-shadow(0 0 4px rgba(0,0,0,0.4))',
+                }}
+              />
+            ) : (
+              <FavoriteBorder
+                sx={{
+                  color: 'white',
+                  fontSize: 26,
+                  filter: 'drop-shadow(0 0 4px rgba(0,0,0,0.4))',
+                }}
+              />
+            )}
+          </button>
+
           {club.profileImage ? (
             <Image
               src={club.profileImage}


### PR DESCRIPTION
### Context
Added a heart (like) button to the ClubCard so users can save clubs they’re interested in and view them together later.

### Changes
- Added heart icon (`Favorite`, `FavoriteBorder`) to the top-right corner of `ClubCard`
- Implemented toggle state with subtle hover and active scaling
- Matched existing shadow style for visual consistency with other white icons

### Preview

Before
<img width="1358" height="574" alt="Before" src="https://github.com/user-attachments/assets/9ede2da4-8882-44f2-a080-61f13ca8338b" />

After
<img width="1358" height="574" alt="After" src="https://github.com/user-attachments/assets/83b878c0-01d2-4135-900c-a15ebd17329f" />
