### PR TITLE
Update hover color for sidebar items

### DIFF
--- a/src/components/nav/SidebarItems.tsx
+++ b/src/components/nav/SidebarItems.tsx
@@ -14,7 +14,7 @@ const SidebarItems = ({ cat }: { cat: allCats[number] }) => {
 
   return (
     <Link
-      className={`group flex items-center gap-x-4 rounded-full px-5 py-2.5 transition-colors duration-200 ${active ? 'bg-white shadow-md' : ''} hover:bg-white hover:shadow-md`}
+      className={`group flex items-center gap-x-4 rounded-full px-5 py-2.5 transition-colors duration-200 ${active ? 'bg-white shadow-md' : ''} hover:bg-blue-200 hover:shadow-md`}
       href={route}
       target={route.startsWith('http') ? '_blank' : ''}
     >


### PR DESCRIPTION
Resolves #299  

Changes the hover background color from white to blue. We could also change the color of the icon and text. We can discuss during the meeting or please leave a comment with any ideas.

Before:
<img width="351" height="133" alt="image" src="https://github.com/user-attachments/assets/44ca6bea-6373-4bd5-8c1c-f806a54b2520" />

After:
<img width="357" height="148" alt="image" src="https://github.com/user-attachments/assets/fa048ca6-a0f7-4dda-9596-20deafe441a3" />
