### PR TITLE
remove active/inactive status

### DIFF
--- a/src/components/club/listing/ClubInfoSegment.tsx
+++ b/src/components/club/listing/ClubInfoSegment.tsx
@@ -35,9 +35,6 @@ const ClubInfoSegment: FC<{
           )}
           <div className="mt-2 flex w-36 justify-between">
             <p className="text-sm text-slate-400">Active</p>
-            <p className="text-right text-sm text-slate-600">
-              {isActive ? 'Present' : 'Inactive'}
-            </p>
           </div>
         </div>
         <div className="w-full md:w-2/3">


### PR DESCRIPTION
We're currently in the process of updating the directory pages for clubs, but our design head had an encounter in the wild of a club being annoyed about their club being listed as *inactive*. Because of this I think it would be best to remove this info till we come up with better language for communicate how up to date a listing is.