### PR TITLE
update next.js to fix new RCEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "drizzle-orm": "^0.44.3",
         "drizzle-zod": "^0.8.2",
         "formidable": "^3.5.4",
-        "next": "^15.5.6",
+        "next": "^15.5.9",
         "postgres": "^3.3.5",
         "react": "19.2.0",
         "react-dom": "19.2.0",
@@ -3477,9 +3477,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.7.tgz",
-      "integrity": "sha512-4h6Y2NyEkIEN7Z8YxkA27pq6zTkS09bUSYC0xjd0NpwFxjnIKeZEeH591o5WECSmjpUhLn3H2QLJcDye3Uzcvg==",
+      "version": "15.5.9",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.9.tgz",
+      "integrity": "sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -16570,12 +16570,12 @@
       "peer": true
     },
     "node_modules/next": {
-      "version": "15.5.7",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.5.7.tgz",
-      "integrity": "sha512-+t2/0jIJ48kUpGKkdlhgkv+zPTEOoXyr60qXe68eB/pl3CMJaLeIGjzp5D6Oqt25hCBiBTt8wEeeAzfJvUKnPQ==",
+      "version": "15.5.9",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.9.tgz",
+      "integrity": "sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.5.7",
+        "@next/env": "15.5.9",
         "@swc/helpers": "0.5.15",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "drizzle-orm": "^0.44.3",
     "drizzle-zod": "^0.8.2",
     "formidable": "^3.5.4",
-    "next": "^15.5.6",
+    "next": "^15.5.9",
     "postgres": "^3.3.5",
     "react": "19.2.0",
     "react-dom": "19.2.0",


### PR DESCRIPTION
See [this](https://vercel.com/kb/bulletin/security-bulletin-cve-2025-55184-and-cve-2025-55183?inf_ver=2&inf_ctx=iWs_5UZHYW4A-9dbRUIKcM9Ibnp29XXXEh-M83BnkrXsL45pK2vNr_-V0eBYLxlSaj0fnF-VbF7oT1xNjqLdm8FRUnXogwcL1LzKfBgImJ45AUY1gryTZgIbgKA0c3G53qfBxjSSoBgkDb_YfH0HPntmYKlTlOMWXDEzdrdi5R7GKvn8aCjZFoPSOkkOSPIbSTuDN6o3XwqvjYGWG0t2i7ABGItzA9sVpUOrrZS1ZCZlwqAAcTkzA-eec9mGQgF8mynUxHrPOZMRGdFGDBqPUtOI4-jI5tnhyreow34izG9zBhOia-_YDPVbK4HI5AXOB2O6uO701v1QwpJbn5EzGg%3D%3D#patched-versions) blog post

"Following the [React2Shell](https://vercel.com/kb/bulletin/react2shell) disclosure, increased community research into React Server Components surfaced two additional vulnerabilities that require patching: a high-severity Denial of Service ([CVE-2025-55184](https://www.cve.org/CVERecord?id=CVE-2025-55184)) and a medium-severity Source Code Exposure ([CVE-2025-55183](https://www.cve.org/CVERecord?id=CVE-2025-55183)). They affect React 19 and frameworks that use it, like Next.js."