### PR TITLE
Migrate page views from only past week

### DIFF
--- a/scripts/migratePageViews.ts
+++ b/scripts/migratePageViews.ts
@@ -25,11 +25,14 @@ const analyticsDataClient = new BetaAnalyticsDataClient({
 
 async function getPageViews() {
   console.log('Fetching page views from Google Analytics...');
+  const oneWeekAgo = new Date();
+  oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
+  const oneWeekAgoString = oneWeekAgo.toISOString().split('T')[0];
   const [response] = await analyticsDataClient.runReport({
     property: `properties/${process.env.GOOGLE_ANALYTICS_PROPERTY_ID}`,
     dimensions: [{ name: 'pagePath' }],
     metrics: [{ name: 'screenPageViews' }],
-    dateRanges: [{ startDate: '2015-08-14', endDate: 'yesterday' }],
+    dateRanges: [{ startDate: oneWeekAgoString, endDate: 'yesterday' }],
     dimensionFilter: {
       filter: {
         fieldName: 'pagePath',


### PR DESCRIPTION
When a club changes their slug the next time the script that pulls page views from google analytics runs itll set their page views to 0, lowering them in the homepage ranking. This changes the script to only pull page views from the past week so they can quickly recover. It'll also make the homepage ordering more dynamic.