### PR TITLE
Don't change updated at from admin changes

### DIFF
--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -99,14 +99,6 @@ export const adminRouter = createTRPCRouter({
           });
       }
 
-      // Updated at
-      await ctx.db
-        .update(club)
-        .set({
-          updatedAt: new Date(),
-        })
-        .where(eq(club.id, input.clubId));
-
       // Return new officers
       const newOfficers = await ctx.db.query.userMetadataToClubs.findMany({
         where: and(


### PR DESCRIPTION
Resolves #486 

I can't track how many orgs have gone in and made changes to their listing by looking for orgs with a non null "updatedAt" field because when I add an admin to a club it changes the "updatedAt" time. Which is my fault but this should help.