### PR TITLE
Bump Gemini version

### DIFF
--- a/src/server/api/routers/ai.ts
+++ b/src/server/api/routers/ai.ts
@@ -109,7 +109,7 @@ Maintain strict formatting:
 `;
 
       const response = await ai.models.generateContent({
-        model: 'gemini-2.0-flash-lite',
+        model: 'gemini-2.5-flash-lite',
         contents: prompt,
       });
 


### PR DESCRIPTION
Got this email:

> We're writing to let you know that as previously communicated, we are discontinuing certain [Generative AI models on Vertex AI](https://c.gle/ANnMTcb32D-MaOcPl-MPBksG6540UrBXaLauReyPYYeKmS8ntEy2xNA-JQCwe-ACwn0Yj5sirw1VEmwCyVrdAKfQUMEapTHYXizp-jbpkAwUoTE1vQtus8-y1gQpgTteE6_HQ-WLJLZcnpORwn5HX6Cnp92b2J3QLqGOsun_bijgS0YuzzO7wy645A). We are updating Gemini 2.0 Flash and Flash Lite retirement dates to March 3, 2026. Additionally, gemini-2.5-flash-preview-09-2025 will shut down on January 15, 2026.

Pricing /1M tokens for gemini-2.0-flash-lite and gemini-2.5-flash-lite is $0.075 and $0.1 respectively. So not much more.