### PR TITLE
Brand info color

### DIFF
--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -19,7 +19,7 @@ const lightPalette = {
       light: '#857efc',
       main: '#6266fa',
       dark: '#45449f',
-    }
+    },
   },
 };
 /*const darkPalette = {


### PR DESCRIPTION
Theme the MUI info color to be Nebula colored since we're using it in a couple places.

Before:
<img width="247" height="359" alt="image" src="https://github.com/user-attachments/assets/7868b6bd-ce89-43d1-9404-7266fe5922e5" />

After:
<img width="251" height="360" alt="image" src="https://github.com/user-attachments/assets/34728d0e-1313-4e49-813c-58c71b88da33" />
