### PR TITLE
hotfix: Remove unnecessary procedure check for UUID

### DIFF
--- a/src/server/api/routers/userMetadata.ts
+++ b/src/server/api/routers/userMetadata.ts
@@ -8,7 +8,7 @@ import { user as users } from '@src/server/db/schema/auth';
 import { userMetadata, userMetadataToClubs } from '@src/server/db/schema/users';
 import { createTRPCRouter, protectedProcedure, publicProcedure } from '../trpc';
 
-const byIdSchema = z.object({ id: z.string().uuid() });
+const byIdSchema = z.object({ id: z.string() });
 
 const updateByIdSchema = z.object({
   updateUser: insertUserMetadata.omit({ id: true }),


### PR DESCRIPTION
Users with non-UUID id were not able to access club match due to unnecessary API procedure check