### PR TITLE
Fix: attempting to delete invalid IDs

### DIFF
--- a/src/app/manage/[slug]/(dashboard)/(forms)/Officers.tsx
+++ b/src/app/manage/[slug]/(dashboard)/(forms)/Officers.tsx
@@ -22,7 +22,7 @@ import AddIcon from '@mui/icons-material/Add';
 import Button from '@mui/material/Button';
 import { useStore } from '@tanstack/react-form';
 import { useMutation } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import z from 'zod';
 import Panel from '@src/components/common/Panel';
 import OfficerListItem from '@src/components/manage/OfficerListItem';


### PR DESCRIPTION
Resolves https://utdnebula.sentry.io/issues/7113592710/

New officers are given an ID `new-${currentOfficers.length}` but then when they're removed they're added to the list of IDs to delete because they have an ID. This adds a check so only IDs that don't begin with "new" are added.