### PR TITLE
Fix: Founding date should be month and year

### DIFF
--- a/src/components/club/listing/ClubDetailsCard.tsx
+++ b/src/components/club/listing/ClubDetailsCard.tsx
@@ -34,12 +34,7 @@ export default function ClubDetailsCard({
         <span className="ml-auto text-slate-800 dark:text-slate-200">
           {club.foundingDate.toLocaleDateString('en-US', {
             month: 'short',
-            day: 'numeric',
             year: 'numeric',
-            hour: 'numeric',
-            minute: '2-digit',
-            second: '2-digit',
-            hour12: true,
           })}
         </span>
       </div>,


### PR DESCRIPTION
I made hover on last event and hover display the full date and time instead of just the month and year. I accidentally did the same for the founding date, which only needs to be the month and year, nothing too specific.