### PR TITLE
Search users by contact email Search users by contact email

### DIFF
--- a/src/server/api/routers/userMetadata.ts
+++ b/src/server/api/routers/userMetadata.ts
@@ -190,6 +190,7 @@ export const userMetadataRouter = createTRPCRouter({
           sql`
             CONCAT(${userMetadata.firstName}, ' ', ${userMetadata.lastName}) ILIKE ${q}
             OR ${users.email} ILIKE ${q}
+            OR ${userMetadata.contactEmail} ILIKE ${q}
           `,
         );
 


### PR DESCRIPTION
Adds UTD contact email to the user search backend so searches match full name, account email, or UTD email. This improves UserSearchBar suggestions for users whose UTD email is the primary identifier.