### PR TITLE
Calendar Sync Bugfixes

### DIFF
--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -114,8 +114,12 @@ export const eventRouter = createTRPCRouter({
 
       try {
         const whereCondition = includePast
-          ? eq(events.clubId, clubId)
-          : and(eq(events.clubId, clubId), gte(events.endTime, now));
+          ? and(eq(events.clubId, clubId), eq(events.status, 'approved'))
+          : and(
+              eq(events.clubId, clubId),
+              gte(events.endTime, now),
+              eq(events.status, 'approved'),
+            );
         const result = await ctx.db
           .select({ value: count() })
           .from(events)


### PR DESCRIPTION
Page count should be based on approved events only

Additional Issues:
- [ ] tbd, but making event's {id & club_id} primary key is super important imo. One edge case is when Club A desyncs a calendar but keeps past events and club B syncs, past events are now gone from club A (club B "owns" them now)