### PR TITLE
Validate event end time after start

### DIFF
--- a/src/utils/formSchemas.ts
+++ b/src/utils/formSchemas.ts
@@ -207,7 +207,7 @@ export const createEventSchema = baseEventSchema.refine(
 export const editEventFormSchema = baseEventFormSchema.refine(
   (data) => data.endTime > data.startTime,
   {
-    message: 'End time must be after start time.',
+    message: 'End time must be after start time',
     path: ['endTime'],
   },
 );


### PR DESCRIPTION
Adds Zod refinements to event create/edit forms to ensure end time is after start time and surfaces a field error on endTime, lmk if there's any issue with formatting, if need I can add some comments for better ... readability?  