### PR TITLE
Allow alias to be empty

### DIFF
--- a/src/utils/formSchemas.ts
+++ b/src/utils/formSchemas.ts
@@ -88,9 +88,11 @@ export const editClubFormSchema = z.object({
     .max(100, 'Character limit reached'),
   alias: z
     .string()
-    .min(2, 'Alias must be at least 2 characters')
     .max(100, 'Character limit reached')
-    .nullable(),
+    .nullable()
+    .refine((val) => val === null || val.length === 0 || val.length >= 2, {
+      message: 'Alias must be at least 2 characters',
+    }),
   description: z
     .string()
     .min(1, 'Description is required')
@@ -109,9 +111,11 @@ export const editClubDetailsSchema = z.object({
     .max(100, 'Character limit reached'),
   alias: z
     .string()
-    .min(2, 'Alias must be at least 2 characters')
     .max(100, 'Character limit reached')
-    .nullable(),
+    .nullable()
+    .refine((val) => val === null || val.length === 0 || val.length >= 2, {
+      message: 'Alias must be at least 2 characters',
+    }),
   description: z
     .string()
     .min(1, 'Description is required')


### PR DESCRIPTION
If someone adds a character to alias then deletes it, it would show an error. Fixed this by allowing alias to be empty or between 2 and 100 characters.