### PR TITLE
Preserve image on edit

### DIFF
--- a/src/components/events/EventForm.tsx
+++ b/src/components/events/EventForm.tsx
@@ -109,7 +109,7 @@ const EventForm = ({ mode = 'create', club, event }: EventFormProps) => {
     onSubmit: async ({ value, formApi }) => {
       if (mode === 'edit' && event) {
         // Image
-        let imageUrl = null;
+        let imageUrl = event.image;
         const iImageIsDirty = !formApi.getFieldMeta('image')?.isDefaultValue;
         if (iImageIsDirty) {
           if (value.image === null) {


### PR DESCRIPTION
If `iImageIsDirty` is false, we want to be giving the same image URL back to the update function, not null.

This wasn't removing images on edit but it seemed wrong.