### PR TITLE
Fix calendar bugs 2

### DIFF
--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -226,7 +226,7 @@ function generateEvent(
     description: event.description,
     image: imageUrl,
     recurrence: JSON.stringify(event.recurrence),
-    recurenceId: event.recurenceEventId,
+    recurenceId: event.recurringEventId,
     startTime: event.start.date
       ? new TZDateMini(event.start.date, 'America/Chicago')
       : event.start.dateTime
@@ -415,7 +415,7 @@ const eventSchema = z.object({
   summary: z.string(),
   description: z.string().optional(),
   recurrence: z.string().array().optional(),
-  recurenceEventId: z.string().optional(),
+  recurringEventId: z.string().optional(),
   etag: z.string(),
   location: z.string().optional(),
   start: z.object({


### PR DESCRIPTION
Made displayname optional for an organizer (prevented Comets for Better Transit from syncing events from an acct without a set name).

Thanks @democat3457 