### PR TITLE
Opengraph image lint fix

### DIFF
--- a/src/app/directory/[slug]/opengraph-image.tsx
+++ b/src/app/directory/[slug]/opengraph-image.tsx
@@ -32,6 +32,7 @@ export default async function Image({ params }: { params: { slug: string } }) {
   const interBuffer = await loadGoogleFont('Inter', 600);
 
   const background = (
+    // eslint-disable-next-line @next/next/no-img-element
     <img
       // @ts-expect-error ArrayBuffers are allowed as an img source
       src={gradientBuffer}
@@ -103,7 +104,7 @@ export default async function Image({ params }: { params: { slug: string } }) {
               overflow: 'hidden',
             }}
           >
-            {}
+            {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={clubData.profileImage!}
               alt={clubData.name + ' logo'}
@@ -179,7 +180,7 @@ export default async function Image({ params }: { params: { slug: string } }) {
                   height: 35,
                 }}
               >
-                {}
+                {/* eslint-disable-next-line @next/next/no-img-element */}
                 <img
                   // @ts-expect-error ArrayBuffers are allowed
                   src={people_alt_icon_buffer}


### PR DESCRIPTION
Fixes `@next/next/no-img-element` warning for `img`s in `src\app\directory\[slug]\opengraph-image.tsx`.