### PR TITLE
Cache bust fix

### DIFF
--- a/src/app/directory/[slug]/opengraph-image.tsx
+++ b/src/app/directory/[slug]/opengraph-image.tsx
@@ -2,6 +2,7 @@ import { eq } from 'drizzle-orm';
 import { ImageResponse } from 'next/og';
 import { UTDClubsLogoStandalone } from '@src/icons/UTDClubsLogo';
 import { db } from '@src/server/db';
+import { addVersionToImage } from '@src/utils/imageCacheBust';
 
 export const runtime = 'edge';
 export const alt = 'Club Details';
@@ -106,7 +107,10 @@ export default async function Image({ params }: { params: { slug: string } }) {
           >
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
-              src={`${clubData.profileImage!}?v=${clubData.updatedAt?.getTime()}`}
+              src={addVersionToImage(
+                clubData.profileImage!,
+                clubData.updatedAt?.getTime(),
+              )}
               alt={clubData.name + ' logo'}
               style={{
                 width: '100%',

--- a/src/app/manage/[slug]/(dashboard)/(forms)/Details.tsx
+++ b/src/app/manage/[slug]/(dashboard)/(forms)/Details.tsx
@@ -14,6 +14,7 @@ import { SelectClub } from '@src/server/db/models';
 import { useTRPC } from '@src/trpc/react';
 import { useAppForm } from '@src/utils/form';
 import { editClubFormSchema } from '@src/utils/formSchemas';
+import { addVersionToImage } from '@src/utils/imageCacheBust';
 
 type DetailsProps = {
   club: SelectClub;
@@ -143,7 +144,10 @@ const Details = ({ club }: DetailsProps) => {
                     onBlur={field.handleBlur}
                     fallbackUrl={
                       clubDetails!.profileImage
-                        ? `${clubDetails!.profileImage}?v=${clubDetails!.updatedAt?.getTime()}`
+                        ? addVersionToImage(
+                            clubDetails!.profileImage,
+                            clubDetails!.updatedAt?.getTime(),
+                          )
                         : undefined
                     }
                     onChange={(e) => {
@@ -169,7 +173,10 @@ const Details = ({ club }: DetailsProps) => {
                     value={field.state.value}
                     fallbackUrl={
                       clubDetails!.bannerImage
-                        ? `${clubDetails!.bannerImage}?v=${clubDetails!.updatedAt?.getTime()}`
+                        ? addVersionToImage(
+                            clubDetails!.bannerImage,
+                            clubDetails!.updatedAt?.getTime(),
+                          )
                         : undefined
                     }
                     onChange={(e) => {

--- a/src/components/club/ClubCard.tsx
+++ b/src/components/club/ClubCard.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { BaseCard } from '@src/components/common/BaseCard';
 import type { SelectClub as Club } from '@src/server/db/models';
+import { addVersionToImage } from '@src/utils/imageCacheBust';
 import { convertMarkdownToPlaintext } from '@src/utils/markdown';
 import JoinButton, { JoinButtonSkeleton } from './JoinButton';
 
@@ -28,7 +29,10 @@ const ClubCard = ({ club, priority = false, manageView = false }: Props) => {
           <div className="absolute inset-0 h-full w-full bg-white dark:bg-neutral-900" />
           {club.profileImage && (
             <Image
-              src={`${club.profileImage}?v=${club.updatedAt?.getTime()}`}
+              src={addVersionToImage(
+                club.profileImage,
+                club.updatedAt?.getTime(),
+              )}
               fill
               alt={club.name + ' logo'}
               priority={priority}

--- a/src/components/club/listing/ClubEventHeader.tsx
+++ b/src/components/club/listing/ClubEventHeader.tsx
@@ -4,6 +4,7 @@ import type {
   SelectContact as Contacts,
   SelectClub,
 } from '@src/server/db/models';
+import { addVersionToImage } from '@src/utils/imageCacheBust';
 
 type Club = SelectClub & {
   contacts?: Contacts[];
@@ -17,7 +18,7 @@ const ClubEventHeader = async ({ club }: { club: Club }) => {
   return (
     <BaseCard className="relative w-full aspect-[4.5/1] overflow-hidden">
       <Image
-        src={`${club.bannerImage}?v=${club.updatedAt?.getTime()}`}
+        src={addVersionToImage(club.bannerImage, club.updatedAt?.getTime())}
         alt="Club banner"
         fill
         className="object-cover object-center"

--- a/src/components/club/listing/ClubTitle.tsx
+++ b/src/components/club/listing/ClubTitle.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import { ClubTags } from '@src/components/common/ClubTags';
 import { type RouterOutputs } from '@src/trpc/shared';
+import { addVersionToImage } from '@src/utils/imageCacheBust';
 import JoinButton from '../JoinButton';
 
 const ClubTitle = async ({
@@ -18,7 +19,10 @@ const ClubTitle = async ({
       >
         {club.profileImage && (
           <Image
-            src={`${club.profileImage}?v=${club.updatedAt?.getTime()}`}
+            src={addVersionToImage(
+              club.profileImage,
+              club.updatedAt?.getTime(),
+            )}
             alt={club.name + ' logo'}
             width={128}
             height={128}

--- a/src/components/events/EventCard.tsx
+++ b/src/components/events/EventCard.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { useState } from 'react';
 import { BaseCard } from '@src/components/common/BaseCard';
 import { type RouterOutputs } from '@src/trpc/shared';
+import { addVersionToImage } from '@src/utils/imageCacheBust';
 import ClientEventTime from './ClientEventTime';
 import EventDeleteButton from './EventDeleteButton';
 import EventRegisterButton, {
@@ -41,7 +42,10 @@ const EventCard = ({ event, view = 'normal', className }: EventCardProps) => {
           {event.club.profileImage && (!showEventImage || !imgLoaded) && (
             <Image
               fill
-              src={`${event.club.profileImage}?v=${event.club.updatedAt?.getTime()}`}
+              src={addVersionToImage(
+                event.club.profileImage,
+                event.club.updatedAt?.getTime(),
+              )}
               alt="Club Profile"
               className="object-cover object-center"
             />
@@ -50,7 +54,7 @@ const EventCard = ({ event, view = 'normal', className }: EventCardProps) => {
           {showEventImage && (
             <Image
               fill
-              src={`${event.image!}?v=${event.updatedAt.getTime()}`}
+              src={addVersionToImage(event.image!, event.updatedAt.getTime())}
               alt="Event Image"
               className={`object-cover object-center transition-opacity duration-300 ${
                 imgLoaded ? 'opacity-100' : 'opacity-0'

--- a/src/components/events/EventForm.tsx
+++ b/src/components/events/EventForm.tsx
@@ -19,6 +19,7 @@ import {
   createEventFormSchema,
   editEventFormSchema,
 } from '@src/utils/formSchemas';
+import { addVersionToImage } from '@src/utils/imageCacheBust';
 import EventCard, { EventCardSkeleton } from './EventCard';
 
 type EventFormProps =
@@ -200,7 +201,10 @@ const EventForm = ({ mode = 'create', club, event }: EventFormProps) => {
                   value={field.state.value}
                   fallbackUrl={
                     event?.image
-                      ? `${event.image}?v=${event.updatedAt.getTime()}`
+                      ? addVersionToImage(
+                          event.image,
+                          event.updatedAt.getTime(),
+                        )
                       : undefined
                   }
                   onBlur={field.handleBlur}

--- a/src/components/events/listing/EventDescriptionCard.tsx
+++ b/src/components/events/listing/EventDescriptionCard.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react';
 import Panel from '@src/components/common/Panel';
 import ExpandableMarkdownText from '@src/components/ExpandableMarkdownText';
 import { RouterOutputs } from '@src/trpc/shared';
+import { addVersionToImage } from '@src/utils/imageCacheBust';
 
 type EventDescriptionCardProps = {
   event: NonNullable<RouterOutputs['event']['getListingInfo']>;
@@ -34,7 +35,7 @@ export default function EventDescriptionCard({
             }`}
           >
             <Image
-              src={`${event.image!}?v=${event.updatedAt.getTime()}`}
+              src={addVersionToImage(event.image!, event.updatedAt.getTime())}
               alt="Event poster"
               height={256}
               width={512}
@@ -75,7 +76,7 @@ export default function EventDescriptionCard({
           </IconButton>
           <div className="relative w-full h-full flex items-center justify-center">
             <Image
-              src={`${event.image!}?v=${event.updatedAt.getTime()}`}
+              src={addVersionToImage(event.image!, event.updatedAt.getTime())}
               alt="Event poster fullscreen"
               fill
               unoptimized

--- a/src/components/events/listing/EventHostClubCard.tsx
+++ b/src/components/events/listing/EventHostClubCard.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import Panel from '@src/components/common/Panel';
 import { RouterOutputs } from '@src/trpc/shared';
+import { addVersionToImage } from '@src/utils/imageCacheBust';
 
 type EventHostClubCardProps = {
   club: NonNullable<RouterOutputs['event']['getListingInfo']>['club'];
@@ -21,7 +22,10 @@ export default function EventHostClubCard({
         >
           {club.profileImage && (
             <Image
-              src={`${club.profileImage}?v=${club.updatedAt?.getTime()}`}
+              src={addVersionToImage(
+                club.profileImage,
+                club.updatedAt?.getTime(),
+              )}
               alt={club.name + ' logo'}
               width={32}
               height={32}

--- a/src/components/settings/forms/JoinedClubs.tsx
+++ b/src/components/settings/forms/JoinedClubs.tsx
@@ -17,6 +17,7 @@ import Confirmation from '@src/components/Confirmation';
 import MemberRoleChip from '@src/components/manage/MemberRoleChip';
 import { SelectUserMetadataToClubsWithClub } from '@src/server/db/models';
 import { useTRPC } from '@src/trpc/react';
+import { addVersionToImage } from '@src/utils/imageCacheBust';
 
 type ClubsProps = {
   joinedClubs: SelectUserMetadataToClubsWithClub[];
@@ -111,7 +112,10 @@ function ClubListItem({ joinedClub, onLeave }: ClubListItemProps) {
           <div className="min-w-10 min-h-10">
             {club.profileImage && (
               <Image
-                src={`${club.profileImage}?v=${club.updatedAt?.getTime()}`}
+                src={addVersionToImage(
+                  club.profileImage,
+                  club.updatedAt?.getTime(),
+                )}
                 alt={club.name + ' logo'}
                 width={40}
                 height={40}

--- a/src/utils/imageCacheBust.ts
+++ b/src/utils/imageCacheBust.ts
@@ -1,0 +1,6 @@
+export function addVersionToImage(src: string, version?: number) {
+  if (!version) return src;
+  const url = new URL(src);
+  url.searchParams.set('v', String(version));
+  return url.toString();
+}


### PR DESCRIPTION
Some clubs still have the old format of URLs that already has query parameters (https://storage.googleapis.com/download/storage/v1/b/utdnebula_jupiter/o/654d361fbfe4308bcdfc4145-profile?generation=1765235601132586&alt=media), so adding another one (?v=1769832468178) broke them.