### PR TITLE
Sort same-day events by start timeSort events by start time

### DIFF
--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -223,6 +223,7 @@ export const eventRouter = createTRPCRouter({
             ),
           );
         },
+        orderBy: (event, { asc }) => [asc(event.startTime)],
         with: {
           club: true,
         },


### PR DESCRIPTION
Adds orderBy: asc(startTime) to the events query so same-day events appear in chronological order
Closes #603

Replaces #615 (which was branched off the wrong base)