### PR TITLE
Only show pending clubs in badge

### DIFF
--- a/src/components/nav/NavMenu.tsx
+++ b/src/components/nav/NavMenu.tsx
@@ -11,10 +11,10 @@ import SidebarItems from './SidebarItems';
 
 type NavMenuProps = {
   userCapabilites: Array<(typeof personalCats)[number]>;
-  notApprovedCount: number | null;
+  pendingClubsCount: number | null;
 };
 
-const NavMenu = ({ userCapabilites, notApprovedCount }: NavMenuProps) => {
+const NavMenu = ({ userCapabilites, pendingClubsCount }: NavMenuProps) => {
   return (
     <>
       {/* Logo Section */}
@@ -42,7 +42,7 @@ const NavMenu = ({ userCapabilites, notApprovedCount }: NavMenuProps) => {
           {userCapabilites.map((cat) => {
             if (cat === 'Admin') {
               return (
-                <SidebarItems key={cat} cat={cat} badge={notApprovedCount} />
+                <SidebarItems key={cat} cat={cat} badge={pendingClubsCount} />
               );
             }
             return <SidebarItems key={cat} cat={cat} />;

--- a/src/components/nav/Sidebar.tsx
+++ b/src/components/nav/Sidebar.tsx
@@ -14,14 +14,14 @@ const Sidebar = async ({
 }) => {
   const userSidebarCapabilities =
     await api.userMetadata.getUserSidebarCapabilities();
-  let notApprovedCount = null;
+  let pendingClubsCount = null;
   if (userSidebarCapabilities.includes('Admin')) {
-    notApprovedCount = await api.admin.notApprovedCount();
+    pendingClubsCount = await api.admin.pendingClubsCount();
   }
   return (
     <NewSidebar
       userCapabilities={userSidebarCapabilities}
-      notApprovedCount={notApprovedCount}
+      pendingClubsCount={pendingClubsCount}
       homepage={homepage}
       hamburgerColor={hamburgerColor}
     />

--- a/src/components/nav/Slide.tsx
+++ b/src/components/nav/Slide.tsx
@@ -10,12 +10,12 @@ import NavMenu from './NavMenu';
 
 const NewSidebar = ({
   userCapabilities,
-  notApprovedCount,
+  pendingClubsCount,
   homepage = false,
   hamburgerColor = 'dark',
 }: {
   userCapabilities: Array<(typeof personalCats)[number]>;
-  notApprovedCount: number | null;
+  pendingClubsCount: number | null;
   homepage?: boolean;
   hamburgerColor?: ContentComponentColor;
 }) => {
@@ -28,7 +28,7 @@ const NewSidebar = ({
         className={`z-50 ${homepage ? ' drop-shadow-[0_0_4px_rgb(0_0_0_/_0.4)]' : ''}`}
         size="large"
       >
-        <Badge badgeContent={notApprovedCount} color="primary">
+        <Badge badgeContent={pendingClubsCount} color="primary">
           <MenuIcon
             fontSize="inherit"
             className={`${
@@ -56,7 +56,7 @@ const NewSidebar = ({
       >
         <NavMenu
           userCapabilites={userCapabilities}
-          notApprovedCount={notApprovedCount}
+          pendingClubsCount={pendingClubsCount}
         />
         <IconButton
           onClick={() => setOpen(false)}

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -1,5 +1,5 @@
 import { TRPCError } from '@trpc/server';
-import { and, count, desc, eq, inArray, lte, ne } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, lte } from 'drizzle-orm';
 import { z } from 'zod';
 import { club } from '@src/server/db/schema/club';
 import { events } from '@src/server/db/schema/events';
@@ -41,11 +41,11 @@ export const adminRouter = createTRPCRouter({
     });
     return orgs;
   }),
-  notApprovedCount: adminProcedure.query(async ({ ctx }) => {
+  pendingClubsCount: adminProcedure.query(async ({ ctx }) => {
     const result = await ctx.db
       .select({ value: count() })
       .from(club)
-      .where(ne(club.approved, 'approved'));
+      .where(eq(club.approved, 'pending'));
     return result[0]?.value ?? null;
   }),
   deleteClub: adminProcedure


### PR DESCRIPTION
This badge appears for any clubs that are not approved right now and I've changed it to only display the number of pending clubs, as those are the ones that need actions taken on. So rejected and pending deletion clubs are not counted

<img width="557" height="130" alt="image" src="https://github.com/user-attachments/assets/ea19bdac-e377-4748-94f8-7378c3a39f5e" />
