### PR TITLE
fix: remove old refresh tokens if we try and use an invalid one

### DIFF
--- a/src/utils/googleAuth.ts
+++ b/src/utils/googleAuth.ts
@@ -1,5 +1,8 @@
 import { differenceInMinutes } from 'date-fns';
+import { eq } from 'drizzle-orm';
 import { auth } from '@src/server/auth';
+import { db } from '@src/server/db';
+import { user } from '@src/server/db/schema/auth';
 
 export async function getGoogleAccessToken(
   userId: string,
@@ -17,7 +20,10 @@ export async function getGoogleAccessToken(
         body: { providerId: 'google', userId: userId },
       })
     ).accessToken;
-    if (!accessToken) throw new Error('Access Token failed to generate');
+    if (!accessToken) {
+      await db.update(user).set().where(eq(user.id, userId));
+      throw new Error('Access Token failed to generate');
+    }
     return accessToken;
   } else {
     return googleAccount.accessToken;


### PR DESCRIPTION
Was causing issues with users authorizing for calendar sync if their refresh token was stale. this resets the refresh token if it no longer works. 