### PR TITLE
Fixed Issue "User Feedback: Cannot press next button due to feedback overlay #620"

### DIFF
--- a/src/app/get-started/page.tsx
+++ b/src/app/get-started/page.tsx
@@ -17,7 +17,7 @@ export default async function Page() {
   const userMetadata = await api.userMetadata.byId({ id: session.user.id });
 
   return (
-    <main className="h-screen relative">
+    <main className="min-h-screen relative pb-24">
       <div className="fixed inset-0 h-full w-full overflow-hidden bg-royal">
         <Image
           src={'/banner.png'}


### PR DESCRIPTION
Added 24 units of padding to the bottom of the onboarding page so that the next button wouldn't be covered by the report a bug button.