### PR TITLE
Fix typo: permenantly -> permanently

### DIFF
--- a/src/app/manage/[slug]/(dashboard)/(forms)/DeleteClub.tsx
+++ b/src/app/manage/[slug]/(dashboard)/(forms)/DeleteClub.tsx
@@ -68,7 +68,7 @@ export default function DeleteClub({ view, club }: Props) {
           <div className="text-slate-800 dark:text-slate-200">
             {view === 'admin' && (
               <p>
-                This will permenantly delete this organization from UTD Clubs.
+                This will permanently delete this organization from UTD Clubs.
               </p>
             )}
             {view === 'manage' && club.approved === 'approved' && (
@@ -86,7 +86,7 @@ export default function DeleteClub({ view, club }: Props) {
             {view === 'manage' &&
               (club.approved === 'pending' || club.approved === 'rejected') && (
                 <p>
-                  This will permenantly delete your organization from UTD Clubs.
+                  This will permanently delete your organization from UTD Clubs.
                 </p>
               )}
             {view === 'manage' && club.approved === 'deleted' && (
@@ -129,11 +129,11 @@ export default function DeleteClub({ view, club }: Props) {
         contentText={
           view === 'manage' && club.approved === 'approved' ? (
             <>
-              This will mark <b>{club.name}</b> for permenant deletion.
+              This will mark <b>{club.name}</b> for permanent deletion.
             </>
           ) : (
             <>
-              This will permenantly delete <b>{club.name}</b>.
+              This will permanently delete <b>{club.name}</b>.
             </>
           )
         }

--- a/src/components/settings/DeleteButton.tsx
+++ b/src/components/settings/DeleteButton.tsx
@@ -27,7 +27,7 @@ export default function DeleteButton() {
         onClose={() => setOpen(false)}
         contentText={
           <>
-            This will permenantly delete your account. <br />
+            This will permanently delete your account. <br />
             All your account data will be cleared and removed from the platform.
           </>
         }

--- a/src/components/settings/forms/DeleteAccount.tsx
+++ b/src/components/settings/forms/DeleteAccount.tsx
@@ -8,7 +8,7 @@ export default function DeleteAccount() {
       className="bg-red-100 dark:bg-red-950 border border-red-500 dark:border-red-700"
       description={
         <div className="text-slate-800 dark:text-slate-200">
-          <p>This will permenantly delete your account from UTD Clubs.</p>
+          <p>This will permanently delete your account from UTD Clubs.</p>
         </div>
       }
     >


### PR DESCRIPTION
## Summary
- Fixed all misspellings of "permenantly" -> "permanently" and "permenant" -> "permanent" across 3 files

Closes #652

## Test plan
- Verify the corrected text renders properly in the delete account and delete club dialogs