### PR TITLE
use clubRecord instead of club when checking calendarId for `disableSync`

### DIFF
--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -596,7 +596,7 @@ export const eventRouter = createTRPCRouter({
             eq(events.google, true),
             clubRecord.calendarId
               ? or(
-                  eq(events.calendarId, club.calendarId),
+                  eq(events.calendarId, clubRecord.calendarId),
                   isNull(events.calendarId),
                 )
               : undefined,


### PR DESCRIPTION
We're in the events update, so referencing club causes it to error. clubRecord exists already and has the calendarId as a string.