### PR TITLE
fix: allow editing past GCal events after unsync

### DIFF
--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -604,6 +604,26 @@ export const eventRouter = createTRPCRouter({
           ),
         );
 
+      // Mark kept past events as non-google so they become editable
+      if (input.keepPastEvents) {
+        await ctx.db
+          .update(events)
+          .set({ google: false })
+          .where(
+            and(
+              eq(events.clubId, input.clubId),
+              eq(events.google, true),
+              lte(events.startTime, new Date()),
+              clubRecord.calendarId
+                ? or(
+                    eq(events.calendarId, clubRecord.calendarId),
+                    isNull(events.calendarId),
+                  )
+                : undefined,
+            ),
+          );
+      }
+
       // remove google calendar info from the club
       await ctx.db
         .update(club)

--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -159,6 +159,7 @@ export async function syncCalendar(
                   'createdAt',
                   'updatedAt',
                   'calendarId',
+                  'google',
                 ]),
               });
           }


### PR DESCRIPTION
## Summary
Fixes #643

When you unsync your Google Calendar but keep past events, those events were still locked as "Google events," so you couldn't edit or delete them. The whole point of keeping them is so you can manage them yourself.

**What this PR does:**
- After unsyncing, past events that are kept now have their `google` flag set to `false`, making them fully editable
- If you resync the same calendar later, those events get picked back up by Google Calendar sync automatically