### PR TITLE
Event link preview and meta tags (#593)

### DIFF
--- a/src/app/directory/[slug]/opengraph-image.tsx
+++ b/src/app/directory/[slug]/opengraph-image.tsx
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { ImageResponse } from 'next/og';
 import { UTDClubsLogoStandalone } from '@src/icons/UTDClubsLogo';
 import { db } from '@src/server/db';
@@ -20,7 +20,7 @@ export default async function Image({ params }: { params: { slug: string } }) {
     interBuffer,
   ] = await Promise.all([
     db.query.club.findFirst({
-      where: (club) => eq(club.slug, slug),
+      where: (club) => and(eq(club.slug, slug), eq(club.approved, 'approved')),
       with: {
         userMetadataToClubs: {
           columns: { userId: true },

--- a/src/app/events/[id]/opengraph-image.tsx
+++ b/src/app/events/[id]/opengraph-image.tsx
@@ -1,0 +1,334 @@
+import { and, eq } from 'drizzle-orm';
+import { ImageResponse } from 'next/og';
+import { UTDClubsLogoStandalone } from '@src/icons/UTDClubsLogo';
+import { db } from '@src/server/db';
+import { addVersionToImage } from '@src/utils/imageCacheBust';
+
+export const runtime = 'edge';
+export const alt = 'Event Details';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+function formatEventDate(startTime: Date, endTime: Date): string {
+  const dateOptions: Intl.DateTimeFormatOptions = {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+  };
+  const timeOptions: Intl.DateTimeFormatOptions = {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  };
+
+  const startDate = startTime.toLocaleDateString('en-US', dateOptions);
+  const startTimeStr = startTime.toLocaleTimeString('en-US', timeOptions);
+  const endTimeStr = endTime.toLocaleTimeString('en-US', timeOptions);
+
+  const sameDay = startTime.toDateString() === endTime.toDateString();
+  if (sameDay) {
+    return `${startDate}, ${startTimeStr} - ${endTimeStr}`;
+  }
+  const endDate = endTime.toLocaleDateString('en-US', dateOptions);
+  return `${startDate}, ${startTimeStr} - ${endDate}, ${endTimeStr}`;
+}
+
+export default async function Image({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const id = (await params).id;
+
+  const eventData = await db.query.events.findFirst({
+    where: (events) => and(eq(events.id, id), eq(events.status, 'approved')),
+    with: {
+      club: {
+        columns: { name: true, profileImage: true, updatedAt: true },
+      },
+    },
+  });
+
+  const gradientBuffer = await fetch(
+    new URL('../../../../public/images/landingGradient.png', import.meta.url),
+  ).then((res) => res.arrayBuffer());
+
+  const baiJamjureeBuffer = await loadGoogleFont('Bai Jamjuree', 700);
+  const interBuffer = await loadGoogleFont('Inter', 600);
+
+  const background = (
+    <img
+      // @ts-expect-error ArrayBuffers are allowed as an img source
+      src={gradientBuffer}
+      alt="background gradient"
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        objectFit: 'cover',
+      }}
+    />
+  );
+
+  if (!eventData) {
+    return new ImageResponse(
+      <div
+        style={{
+          position: 'relative',
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: 'white',
+        }}
+      >
+        {background}
+        <h1>Event Not Found</h1>
+      </div>,
+      { ...size },
+    );
+  }
+
+  const hasImage = !!eventData.image;
+  const dateStr = formatEventDate(eventData.startTime, eventData.endTime);
+
+  return new ImageResponse(
+    <div
+      style={{
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: hasImage ? 'space-between' : 'center',
+        color: 'white',
+      }}
+    >
+      {background}
+
+      {/* Left Side (renders if there's an event image) */}
+      {hasImage && (
+        <div
+          style={{ display: 'flex', width: '45%', justifyContent: 'center' }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              position: 'relative',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 350,
+              height: 350,
+              borderRadius: '20px',
+              boxShadow: '0 0 16px rgba(0,0,0,0.4)',
+              overflow: 'hidden',
+            }}
+          >
+            <img
+              src={addVersionToImage(
+                eventData.image!,
+                eventData.updatedAt.getTime(),
+              )}
+              alt={eventData.name + ' event image'}
+              style={{
+                width: '100%',
+                objectFit: 'contain',
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Right Side (Content) */}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          width: '95%',
+          alignItems: hasImage ? 'flex-start' : 'center',
+          paddingRight: hasImage ? '40px' : '0px',
+          paddingLeft: hasImage ? '0px' : '25px',
+        }}
+      >
+        <h1
+          style={{
+            fontFamily: 'Bai Jamjuree',
+            fontSize: '56px',
+            fontWeight: 'bold',
+            margin: '0 0 16px 0',
+            lineHeight: 1.1,
+            textShadow: '0 0 16px rgba(0,0,0,0.4)',
+            maxWidth: hasImage ? '55%' : '90%',
+            textAlign: hasImage ? 'left' : 'center',
+            wordBreak: 'break-word',
+            overflowWrap: 'anywhere',
+            overflow: 'hidden',
+            maxHeight: '200px',
+          }}
+        >
+          {eventData.name}
+        </h1>
+
+        {/* Date & Time */}
+        <div
+          style={{
+            display: 'flex',
+            fontFamily: 'Inter',
+            fontSize: '24px',
+            margin: '0 0 12px 0',
+            textShadow: '0 0 4px rgba(0,0,0,0.4)',
+            maxWidth: hasImage ? '55%' : '90%',
+            textAlign: hasImage ? 'left' : 'center',
+          }}
+        >
+          {dateStr}
+        </div>
+
+        {/* Location */}
+        {eventData.location && (
+          <div
+            style={{
+              display: 'flex',
+              fontFamily: 'Inter',
+              fontSize: '22px',
+              margin: '0 0 16px 0',
+              textShadow: '0 0 4px rgba(0,0,0,0.4)',
+              opacity: 0.9,
+              maxWidth: hasImage ? '55%' : '90%',
+              textAlign: hasImage ? 'left' : 'center',
+            }}
+          >
+            {eventData.location}
+          </div>
+        )}
+
+        {/* Details Container */}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'row',
+            justifyContent: hasImage ? 'flex-start' : 'center',
+            alignItems: 'center',
+            width: '100%',
+            fontFamily: 'Inter',
+            fontSize: '22px',
+            margin: '0 0 16px 0',
+            gap: '12px',
+          }}
+        >
+          {/* Club name */}
+          {eventData.club.profileImage && (
+            <div
+              style={{
+                display: 'flex',
+                position: 'relative',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 32,
+                height: 32,
+                borderRadius: '50%',
+                overflow: 'hidden',
+              }}
+            >
+              <img
+                src={addVersionToImage(
+                  eventData.club.profileImage,
+                  eventData.club.updatedAt?.getTime(),
+                )}
+                alt={eventData.club.name + ' logo'}
+                style={{
+                  width: '100%',
+                  height: '100%',
+                  objectFit: 'cover',
+                }}
+              />
+            </div>
+          )}
+          <div
+            style={{
+              display: 'flex',
+              textShadow: '0 0 4px rgba(0,0,0,0.4)',
+            }}
+          >
+            {eventData.club.name}
+          </div>
+
+          {/* Divider */}
+          <div
+            style={{
+              width: '2px',
+              height: '25px',
+              backgroundColor: '#d4d4d4',
+              margin: '0 10px 0 9px',
+              alignSelf: 'center',
+            }}
+          />
+
+          {/* Nebula Logo */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              width: 36,
+              height: 36,
+            }}
+          >
+            <UTDClubsLogoStandalone
+              fill="white"
+              style={{
+                width: '100%',
+                height: '100%',
+                objectFit: 'contain',
+              }}
+            />
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              textShadow: '0 0 4px rgba(0,0,0,0.4)',
+            }}
+          >
+            UTD CLUBS
+          </div>
+        </div>
+      </div>
+    </div>,
+    {
+      ...size,
+      fonts: [
+        {
+          name: 'Bai Jamjuree',
+          data: baiJamjureeBuffer,
+          style: 'normal',
+          weight: 700,
+        },
+        {
+          name: 'Inter',
+          data: interBuffer,
+          style: 'normal',
+          weight: 600,
+        },
+      ],
+    },
+  );
+}
+
+async function loadGoogleFont(font: string, weight: number) {
+  const url = `https://fonts.googleapis.com/css2?family=${font}:wght@${weight}&display=swap`;
+  const css = await fetch(url).then((res) => res.text());
+  const resource = css.match(
+    /src: url\((.+)\) format\('(opentype|truetype)'\)/,
+  );
+
+  if (!resource) {
+    throw new Error('Failed to load font');
+  }
+
+  return fetch(resource[1]!).then((res) => res.arrayBuffer());
+}

--- a/src/app/events/[id]/opengraph-image.tsx
+++ b/src/app/events/[id]/opengraph-image.tsx
@@ -33,11 +33,7 @@ function formatEventDate(startTime: Date, endTime: Date): string {
   return `${startDate}, ${startTimeStr} - ${endDate}, ${endTimeStr}`;
 }
 
-export default async function Image({
-  params,
-}: {
-  params: { id: string };
-}) {
+export default async function Image({ params }: { params: { id: string } }) {
   const id = (await params).id;
 
   const eventData = await db.query.events.findFirst({

--- a/src/app/events/[id]/opengraph-image.tsx
+++ b/src/app/events/[id]/opengraph-image.tsx
@@ -1,3 +1,10 @@
+import {
+  format,
+  formatDuration,
+  intervalToDuration,
+  isSameDay,
+  type FormatDistanceToken,
+} from 'date-fns';
 import { and, eq } from 'drizzle-orm';
 import { ImageResponse } from 'next/og';
 import { UTDClubsLogoStandalone } from '@src/icons/UTDClubsLogo';
@@ -9,48 +16,62 @@ export const alt = 'Event Details';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
+const distanceTokenUnits: Partial<Record<FormatDistanceToken, string>> = {
+  xSeconds: 's',
+  xMinutes: 'm',
+  xHours: 'h',
+  xDays: 'd',
+  xMonths: 'mo',
+  xYears: 'y',
+};
+
 function formatEventDate(startTime: Date, endTime: Date): string {
-  const dateOptions: Intl.DateTimeFormatOptions = {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-  };
-  const timeOptions: Intl.DateTimeFormatOptions = {
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true,
-  };
+  const dateStr = format(startTime, 'EEE, LLLL d, yyyy @ h:mm a');
 
-  const startDate = startTime.toLocaleDateString('en-US', dateOptions);
-  const startTimeStr = startTime.toLocaleTimeString('en-US', timeOptions);
-  const endTimeStr = endTime.toLocaleTimeString('en-US', timeOptions);
-
-  const sameDay = startTime.toDateString() === endTime.toDateString();
-  if (sameDay) {
-    return `${startDate}, ${startTimeStr} - ${endTimeStr}`;
+  if (startTime.getTime() === endTime.getTime()) {
+    return dateStr;
   }
-  const endDate = endTime.toLocaleDateString('en-US', dateOptions);
-  return `${startDate}, ${startTimeStr} - ${endDate}, ${endTimeStr}`;
+
+  const duration = formatDuration(
+    intervalToDuration({ start: startTime, end: endTime }),
+    {
+      locale: {
+        formatDistance: (token, count) =>
+          `${count}${distanceTokenUnits[token] ?? ''}`,
+      },
+    },
+  );
+
+  const endStr = isSameDay(startTime, endTime)
+    ? format(endTime, 'h:mm a')
+    : format(endTime, 'EEE, LLLL d, yyyy @ h:mm a');
+
+  return `${dateStr} · ${duration} (till ${endStr})`;
 }
 
 export default async function Image({ params }: { params: { id: string } }) {
-  const id = (await params).id;
+  const { id } = await params;
 
-  const eventData = await db.query.events.findFirst({
-    where: (events) => and(eq(events.id, id), eq(events.status, 'approved')),
-    with: {
-      club: {
-        columns: { name: true, profileImage: true, updatedAt: true },
-      },
-    },
-  });
-
-  const gradientBuffer = await fetch(
-    new URL('../../../../public/images/landingGradient.png', import.meta.url),
-  ).then((res) => res.arrayBuffer());
-
-  const baiJamjureeBuffer = await loadGoogleFont('Bai Jamjuree', 700);
-  const interBuffer = await loadGoogleFont('Inter', 600);
+  const [eventData, gradientBuffer, baiJamjureeBuffer, interBuffer] =
+    await Promise.all([
+      db.query.events.findFirst({
+        where: (events) =>
+          and(eq(events.id, id), eq(events.status, 'approved')),
+        with: {
+          club: {
+            columns: { name: true, profileImage: true, updatedAt: true },
+          },
+        },
+      }),
+      fetch(
+        new URL(
+          '../../../../public/images/landingGradient.png',
+          import.meta.url,
+        ),
+      ).then((res) => res.arrayBuffer()),
+      loadGoogleFont('Bai Jamjuree', 700),
+      loadGoogleFont('Inter', 600),
+    ]);
 
   const background = (
     <img
@@ -194,7 +215,6 @@ export default async function Image({ params }: { params: { id: string } }) {
               fontSize: '22px',
               margin: '0 0 16px 0',
               textShadow: '0 0 4px rgba(0,0,0,0.4)',
-              opacity: 0.9,
               maxWidth: hasImage ? '55%' : '90%',
               textAlign: hasImage ? 'left' : 'center',
             }}
@@ -271,8 +291,8 @@ export default async function Image({ params }: { params: { id: string } }) {
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              width: 36,
-              height: 36,
+              width: 40,
+              height: 40,
             }}
           >
             <UTDClubsLogoStandalone

--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -1,3 +1,10 @@
+import {
+  format,
+  formatDuration,
+  intervalToDuration,
+  isSameDay,
+  type FormatDistanceToken,
+} from 'date-fns';
 import { type Metadata } from 'next';
 import ClubEventHeader from '@src/components/club/listing/ClubEventHeader';
 import EventBody from '@src/components/events/listing/EventBody';
@@ -5,6 +12,15 @@ import EventTitle from '@src/components/events/listing/EventTitle';
 import { EventHeader } from '@src/components/header/Header';
 import { api } from '@src/trpc/server';
 import { convertMarkdownToPlaintext } from '@src/utils/markdown';
+
+const distanceTokenUnits: Partial<Record<FormatDistanceToken, string>> = {
+  xSeconds: 's',
+  xMinutes: 'm',
+  xHours: 'h',
+  xDays: 'd',
+  xMonths: 'mo',
+  xYears: 'y',
+};
 
 type Params = { params: Promise<{ id: string }> };
 
@@ -38,16 +54,24 @@ export async function generateMetadata(props: {
       description: 'Event not found',
     };
 
-  const dateOptions: Intl.DateTimeFormatOptions = {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true,
-  };
-  const startStr = event.startTime.toLocaleString('en-US', dateOptions);
-  const endStr = event.endTime.toLocaleString('en-US', dateOptions);
+  const startStr = format(event.startTime, 'EEE, LLLL d, yyyy @ h:mm a');
+
+  let durationStr = '';
+  if (event.startTime.getTime() !== event.endTime.getTime()) {
+    const duration = formatDuration(
+      intervalToDuration({ start: event.startTime, end: event.endTime }),
+      {
+        locale: {
+          formatDistance: (token, count) =>
+            `${count}${distanceTokenUnits[token] ?? ''}`,
+        },
+      },
+    );
+    const endStr = isSameDay(event.startTime, event.endTime)
+      ? format(event.endTime, 'h:mm a')
+      : format(event.endTime, 'EEE, LLLL d, yyyy @ h:mm a');
+    durationStr = ` · ${duration} (till ${endStr})`;
+  }
 
   let cleanDescription = `${event.name} from ${event.club.name} on UTD Clubs`;
   const textDescription = event.description.replace(/^#+.*$/gm, '');
@@ -64,7 +88,7 @@ export async function generateMetadata(props: {
     }
   }
 
-  const timeDescription = `${startStr} - ${endStr}${event.location ? ` | ${event.location}` : ''}`;
+  const timeDescription = `${startStr}${durationStr}${event.location ? ` | ${event.location}` : ''}`;
 
   return {
     title: event.name,

--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -38,6 +38,17 @@ export async function generateMetadata(props: {
       description: 'Event not found',
     };
 
+  const dateOptions: Intl.DateTimeFormatOptions = {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  };
+  const startStr = event.startTime.toLocaleString('en-US', dateOptions);
+  const endStr = event.endTime.toLocaleString('en-US', dateOptions);
+
   let cleanDescription = `${event.name} from ${event.club.name} on UTD Clubs`;
   const textDescription = event.description.replace(/^#+.*$/gm, '');
 
@@ -53,15 +64,22 @@ export async function generateMetadata(props: {
     }
   }
 
+  const timeDescription = `${startStr} - ${endStr}${event.location ? ` | ${event.location}` : ''}`;
+
   return {
-    title: `${event.name}`,
-    description: cleanDescription,
+    title: event.name,
+    description: `${timeDescription}. ${cleanDescription}`,
     alternates: {
       canonical: `https://clubs.utdnebula.com/events/${event.id}`,
     },
     openGraph: {
+      title: event.name,
       url: `https://clubs.utdnebula.com/events/${event.id}`,
-      description: cleanDescription,
+      description: `${timeDescription}. ${cleanDescription}`,
+      type: 'website',
+    },
+    twitter: {
+      card: 'summary_large_image',
     },
   };
 }


### PR DESCRIPTION
## What's going on here

So right now, if you share a club page link on Discord or iMessage or whatever, you get a nice rich preview with the club name, logo, tags, and member count. But if you share an event link, you just get a boring plain link with no preview image at all. This PR fixes that.

### The OG image (`opengraph-image.tsx`)

I basically followed the same pattern as the club OG image that was already built for #519. The new one lives at `src/app/events/[id]/opengraph-image.tsx` and generates a 1200x630 image that shows:

- The **event name** as the big headline
- The **date and time** (formatted nicely, handles same-day and multi-day events)
- The **location** if there is one
- The **hosting club name** with its profile image (little circular avatar)
- The **UTD Clubs branding** at the bottom

If the event has a banner image, it shows up on the left side of the card (same layout logic as the club OG image with the profile picture). If there's no image, everything centers up.

One thing worth noting: I added a `status = 'approved'` filter on the database query so that pending/rejected/deleted events don't get a real OG image generated for them. The club OG image doesn't do this (it just checks by slug), but for events it felt important since event IDs are less guessable than slugs.

### The metadata (`page.tsx`)

The existing `generateMetadata` was pretty barebones. It had the title and a description, but was missing:

- **Twitter card** (`summary_large_image`) so the OG image actually shows up on Twitter/X
- **Event time** in the description, so when you see the preview you know when it is
- **Location** in the description
- **OpenGraph title** (was only set on the top-level metadata, not in the `openGraph` object)

Now the meta description reads something like: *"Wed, Apr 2, 7:00 PM - Wed, Apr 2, 9:00 PM | ECSS 2.102. ACM Meeting from ACM at UTD on UTD Clubs"*. You get the time, location, and the club name all in one glance.


Closes #593