### PR TITLE
Add remaining aria-labels for accessibility improvementsy

### DIFF
--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -21,6 +21,7 @@ const BackButton = ({ href, ...props }: BackButtonProps) => {
               router.back();
             }
       }
+      aria-label="Go back"
       size="large"
       color="primary"
       {...props}

--- a/src/components/events/listing/EventDescriptionCard.tsx
+++ b/src/components/events/listing/EventDescriptionCard.tsx
@@ -30,6 +30,7 @@ export default function EventDescriptionCard({
         {showImageTrigger && (
           <button
             onClick={() => setOpen(true)}
+            aria-label="View full size event poster"
             className={`w-fit max-h-64 mx-auto mb-6 cursor-zoom-in ${
               imgLoaded ? 'block' : 'hidden' // hide button until loaded
             }`}
@@ -70,6 +71,7 @@ export default function EventDescriptionCard({
         >
           <IconButton
             onClick={() => setOpen(false)}
+            aria-label="Close"
             className="absolute top-4 right-4 text-white z-10"
           >
             <CloseIcon />

--- a/src/components/manage/MemberList/CustomRenderCell.tsx
+++ b/src/components/manage/MemberList/CustomRenderCell.tsx
@@ -88,7 +88,7 @@ export function ContactEmailCell(params: GridRenderCellParams) {
   return (
     <div className="flex gap-1 items-center h-full">
       <Tooltip title={contactEmailsVisible ? 'Hide' : 'Show'}>
-        <IconButton size="small" onClick={handleOnClick}>
+        <IconButton size="small" onClick={handleOnClick} aria-label="Toggle email visibility">
           <div className="flex justify-center items-center text-slate-600 dark:text-slate-400 h-4 *:w-4 *:h-4">
             {contactEmailsVisible ? (
               <VisibilityOutlinedIcon />
@@ -168,6 +168,7 @@ export function ActionsCell(
           {/* This span is required to ensure the error tooltip shows when the IconButton is disabled */}
           <span>
             <IconButton
+              aria-label="Remove member"
               onClick={() => {
                 memberListDeletionState?.deleteSourceModel.setFromRowId(
                   props.id,

--- a/src/components/manage/form/FormImage.tsx
+++ b/src/components/manage/form/FormImage.tsx
@@ -63,6 +63,7 @@ const FormImage = ({
           type="file"
           accept="image/jpeg,image/jpg,image/png,image/svg+xml"
           onBlur={onBlur}
+          aria-label="Upload image"
           onChange={onChange}
           className="absolute inset-0 cursor-pointer text-transparent"
         />


### PR DESCRIPTION
This PR continues accessibility improvements by adding aria-label attributes to remaining interactive elements.

Updated components:
- EventDescriptionCard (Close button, View full size event poster)
- CustomRenderCell (Toggle email visibility, Remove member)
- FormImage (Upload image input)
- BackButton (Go back)

Note:
- EventsTitle.tsx was reviewed but does not contain interactive IconButton elements, so no changes were required there.

These updates improve screen reader accessibility by ensuring that icon-based and interactive elements are properly labeled.

Refs #668