### PR TITLE
feature: show tag count on homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -76,8 +76,9 @@ const Home = async () => {
               <div className="pointer-events-auto mt-8 flex max-w-3xl flex-wrap justify-center gap-x-2 gap-y-2 text-white">
                 {tags.map((tag) => (
                   <TagPill
-                    name={tag}
-                    key={tag}
+                    name={tag.tag}
+                    count={tag.count}
+                    key={tag.tag}
                     className="drop-shadow-[0_0_4px_rgb(0_0_0_/_0.4)]"
                   />
                 ))}

--- a/src/components/AllTags.tsx
+++ b/src/components/AllTags.tsx
@@ -71,7 +71,16 @@ export const AllTags = ({
       >
         {options.map((option) => (
           <MenuItem key={option.tag} onClick={() => handleChange(option.tag)}>
-            <ListItemText primary={`${option.tag} (${option.count})`} />
+            <ListItemText
+              primary={
+                <>
+                  <span>{option.tag}</span>
+                  <span className="ml-2 text-sm text-slate-600 dark:text-slate-400">
+                    ({option.count})
+                  </span>
+                </>
+              }
+            />
           </MenuItem>
         ))}
       </Menu>

--- a/src/components/AllTags.tsx
+++ b/src/components/AllTags.tsx
@@ -11,7 +11,7 @@ export const AllTags = ({
   options = [],
   label = '•••',
 }: {
-  options?: string[];
+  options?: { tag: string; count: number }[];
   label?: string;
 }) => {
   const { tags, setTags, setShouldFocus } = useSearchStore((s) => s);
@@ -48,8 +48,6 @@ export const AllTags = ({
     setShouldFocus(true);
   };
 
-  const sorted = options.sort((a, b) => a.localeCompare(b));
-
   return (
     <>
       <Button
@@ -71,9 +69,9 @@ export const AllTags = ({
           list: { onClick: (e: React.MouseEvent) => e.stopPropagation() },
         }}
       >
-        {sorted.map((tag) => (
-          <MenuItem key={tag} onClick={() => handleChange(tag)}>
-            <ListItemText primary={tag} />
+        {options.map((option) => (
+          <MenuItem key={option.tag} onClick={() => handleChange(option.tag)}>
+            <ListItemText primary={`${option.tag} (${option.count})`} />
           </MenuItem>
         ))}
       </Menu>

--- a/src/components/TagPill.tsx
+++ b/src/components/TagPill.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Tooltip } from '@mui/material';
 import { useSearchStore } from '@src/utils/SearchStoreProvider';
 import { TagChip } from './common/TagChip';
 
@@ -24,20 +25,26 @@ export const TagPill = ({
     });
   }
 
-  const displayName = count !== undefined ? `${name} (${count})` : name;
-
   return (
-    <TagChip
-      tag={displayName}
-      className={
-        'rounded-full font-bold transition-colors ' + (className ?? '')
+    <Tooltip
+      title={
+        count !== undefined ? `${count} ${count === 1 ? 'club' : 'clubs'}` : ''
       }
-      onClick={() => {
-        addTag(name);
-        scroll();
-        setShouldFocus(true);
-      }}
-      onDelete={removeTag}
-    />
+    >
+      <span>
+        <TagChip
+          tag={name}
+          className={
+            'rounded-full font-bold transition-colors ' + (className ?? '')
+          }
+          onClick={() => {
+            addTag(name);
+            scroll();
+            setShouldFocus(true);
+          }}
+          onDelete={removeTag}
+        />
+      </span>
+    </Tooltip>
   );
 };

--- a/src/components/TagPill.tsx
+++ b/src/components/TagPill.tsx
@@ -5,10 +5,12 @@ import { TagChip } from './common/TagChip';
 
 export const TagPill = ({
   name,
+  count,
   removeTag,
   className,
 }: {
   name: string;
+  count?: number;
   removeTag?: () => void;
   className?: string;
 }) => {
@@ -22,9 +24,11 @@ export const TagPill = ({
     });
   }
 
+  const displayName = count !== undefined ? `${name} (${count})` : name;
+
   return (
     <TagChip
-      tag={name}
+      tag={displayName}
       className={
         'rounded-full font-bold transition-colors ' + (className ?? '')
       }

--- a/src/components/manage/form/ClubTagEdit.tsx
+++ b/src/components/manage/form/ClubTagEdit.tsx
@@ -23,9 +23,11 @@ export const ClubTagEdit = ({
 }) => {
   const api = useTRPC();
 
-  const { data: allTags, isFetching } = useQuery(
+  const { data: rawTags, isFetching } = useQuery(
     api.club.distinctTags.queryOptions(),
   );
+  const allTags =
+    rawTags?.map((t: any) => (typeof t === 'string' ? t : t.tag)) ?? [];
 
   const filter = createFilterOptions<string>({});
 
@@ -41,6 +43,16 @@ export const ClubTagEdit = ({
       aria-label="search"
       value={value}
       options={allTags ?? []}
+      renderOption={(props, option) => {
+        const { key, ...otherProps } = props;
+        const original = rawTags?.find((t: any) => t.tag === option);
+
+        return (
+          <li key={key} {...otherProps}>
+            {option} {original ? `(${original.count})` : ''}
+          </li>
+        );
+      }}
       renderInput={(params) => (
         <TextField
           {...params}

--- a/src/components/manage/form/ClubTagEdit.tsx
+++ b/src/components/manage/form/ClubTagEdit.tsx
@@ -4,6 +4,7 @@ import TagIcon from '@mui/icons-material/Tag';
 import Autocomplete, { createFilterOptions } from '@mui/material/Autocomplete';
 import CircularProgress from '@mui/material/CircularProgress';
 import TextField from '@mui/material/TextField';
+import Tooltip from '@mui/material/Tooltip';
 import { useQuery } from '@tanstack/react-query';
 import { TagChip } from '@src/components/common/TagChip';
 import { useTRPC } from '@src/trpc/react';
@@ -53,7 +54,12 @@ export const ClubTagEdit = ({
 
         return (
           <li key={key} {...otherProps}>
-            {option} {original ? `(${original.count})` : ''}
+            <span>{option}</span>
+            {original && (
+              <span className="ml-2 text-sm text-slate-600 dark:text-slate-400">
+                ({original.count})
+              </span>
+            )}
           </li>
         );
       }}
@@ -83,13 +89,27 @@ export const ClubTagEdit = ({
       renderValue={(value, getItemProps) => {
         return value.map((option: string, index: number) => {
           const { key, ...itemProps } = getItemProps({ index });
+          const original = rawTags?.find(
+            (t: { tag: string; count: number }) => t.tag === option,
+          );
+
           return (
-            <TagChip
+            <Tooltip
               key={key}
-              icon={<TagIcon color="inherit" />}
-              tag={option}
-              {...itemProps}
-            />
+              title={
+                original
+                  ? `${original.count} ${original.count === 1 ? 'club' : 'clubs'}`
+                  : ''
+              }
+            >
+              <span>
+                <TagChip
+                  icon={<TagIcon color="inherit" />}
+                  tag={option}
+                  {...itemProps}
+                />
+              </span>
+            </Tooltip>
           );
         });
       }}

--- a/src/components/manage/form/ClubTagEdit.tsx
+++ b/src/components/manage/form/ClubTagEdit.tsx
@@ -27,7 +27,9 @@ export const ClubTagEdit = ({
     api.club.distinctTags.queryOptions(),
   );
   const allTags =
-    rawTags?.map((t: any) => (typeof t === 'string' ? t : t.tag)) ?? [];
+    rawTags?.map((t: { tag: string; count: number } | string) =>
+      typeof t === 'string' ? t : t.tag,
+    ) ?? [];
 
   const filter = createFilterOptions<string>({});
 
@@ -45,7 +47,9 @@ export const ClubTagEdit = ({
       options={allTags ?? []}
       renderOption={(props, option) => {
         const { key, ...otherProps } = props;
-        const original = rawTags?.find((t: any) => t.tag === option);
+        const original = rawTags?.find(
+          (t: { tag: string; count: number }) => t.tag === option,
+        );
 
         return (
           <li key={key} {...otherProps}>

--- a/src/server/api/routers/club.ts
+++ b/src/server/api/routers/club.ts
@@ -136,8 +136,10 @@ export const clubRouter = createTRPCRouter({
   }),
   distinctTags: publicProcedure.query(async ({ ctx }) => {
     try {
-      const tags = (await ctx.db.select().from(usedTags)).map((obj) => obj.tag);
-      return tags;
+      return await ctx.db
+        .select()
+        .from(usedTags)
+        .orderBy(desc(usedTags.count), asc(usedTags.tag));
     } catch (e) {
       console.error(e);
       return [];
@@ -145,10 +147,11 @@ export const clubRouter = createTRPCRouter({
   }),
   topTags: publicProcedure.query(async ({ ctx }) => {
     try {
-      const tags = (await ctx.db.select().from(usedTags).limit(5)).map(
-        (obj) => obj.tag,
-      );
-      return tags;
+      return await ctx.db
+        .select()
+        .from(usedTags)
+        .orderBy(desc(usedTags.count), asc(usedTags.tag))
+        .limit(5);
     } catch (e) {
       console.error(e);
       return [];


### PR DESCRIPTION
Updated the tag system to show the number of clubs using a tag and sort the tags list by this on the homepage and the manage club page. Alphabetical order is the tiebreaker for tags with the same number of clubs using them.
**Homepage example:**
<img width="957" height="584" alt="Screenshot 2026-04-08 at 8 48 09 PM" src="https://github.com/user-attachments/assets/6b1a5745-9bef-4086-a67d-53bc7d0c308d" />

**Club Manage Page example:**
<img width="1156" height="822" alt="Screenshot 2026-04-08 at 8 50 03 PM" src="https://github.com/user-attachments/assets/21686b11-4711-4348-9e9e-849c851b0bf0" />
I updated club.ts to return the whole tag object including the count instead of just the tag name, and updated the other files to handle this new data including a mapping in ClubTagEdit to stop the Autocomplete search functionality from breaking due to expecting a string instead of an object. renderOption is used to display the tag counts in the dropdown on the manage clubs page. I didn't know if I was supposed to put the count inside a tag when its selected in the search bar as well so I didn't.
