### PR TITLE
Fix CSS typo: h=fill should be h-full in manage list items

### DIFF
--- a/src/components/manage/MembershipFormListItem.tsx
+++ b/src/components/manage/MembershipFormListItem.tsx
@@ -127,7 +127,7 @@ const MembershipFormListItem = withForm({
         </div>
         <div
           style={{ gridArea: 'buttons' }}
-          className="flex max-sm:h=fill sm:h-fit max-sm:ml-2 sm:my-2 mr-2"
+          className="flex max-sm:h-full sm:h-fit max-sm:ml-2 sm:my-2 mr-2"
         >
           <Tooltip title="Remove" className="h-fit self-center">
             <IconButton aria-label="remove" onClick={handleRemove}>

--- a/src/components/manage/OfficerListItem.tsx
+++ b/src/components/manage/OfficerListItem.tsx
@@ -127,7 +127,7 @@ const OfficerListItem = withForm({
         </div>
         <div
           style={{ gridArea: 'buttons' }}
-          className="flex max-sm:h=fill sm:h-fit max-sm:ml-2 sm:my-2 mr-2"
+          className="flex max-sm:h-full sm:h-fit max-sm:ml-2 sm:my-2 mr-2"
         >
           <Tooltip title="Remove" className="h-fit self-center">
             <IconButton aria-label="remove" onClick={handleRemove}>


### PR DESCRIPTION
Hi,

This will fix issue in #666 

## what the bug was
Here is a minor typo found in two files, where a Tailwind class uses...

## where it was
src/components/manage/OfficerListItem.tsx (line 130)
src/components/manage/MembershipFormListItem.tsx (line 130)

## what you changed
Change `max-sm:h=fill` to `max-sm:h-full`

