### PR TITLE
feat: composite PK on events table (fixes #611)

### DIFF
--- a/src/components/events/EventDeleteButton.tsx
+++ b/src/components/events/EventDeleteButton.tsx
@@ -81,7 +81,7 @@ export default function EventDeleteButton({
           </>
         }
         onConfirm={() => {
-          deleteEvent.mutate({ id: event.id });
+          deleteEvent.mutate({ id: event.id, clubId: event.clubId });
         }}
         loading={deleteEvent.isPending}
       />

--- a/src/components/events/EventRegisterButton.tsx
+++ b/src/components/events/EventRegisterButton.tsx
@@ -32,15 +32,15 @@ const EventRegisterButton = ({
   const api = useTRPC();
   const queryClient = useQueryClient();
   const { data: registerState, isPending } = useQuery(
-    api.event.registerState.queryOptions({ id: eventId }),
+    api.event.registerState.queryOptions({ id: eventId, clubId }),
   );
 
   const toggleRegistration = useMutation(
     api.event.toggleRegistration.mutationOptions({
-      onMutate: async ({ id }) => {
+      onMutate: async ({ id, clubId }) => {
         const queryKey = [
           ['event', 'registerState'],
-          { input: { id }, type: 'query' },
+          { input: { id, clubId }, type: 'query' },
         ];
 
         // Cancel outgoing refetches
@@ -86,11 +86,11 @@ const EventRegisterButton = ({
           queryClient.setQueryData(context.queryKey, context.previousState);
         }
       },
-      onSettled: (_data, _error, { id }) => {
+      onSettled: (_data, _error, { id, clubId }) => {
         queryClient.invalidateQueries({
           queryKey: [
             ['event', 'registerState'],
-            { input: { id }, type: 'query' },
+            { input: { id, clubId }, type: 'query' },
           ],
         });
       },
@@ -126,7 +126,7 @@ const EventRegisterButton = ({
       return;
     }
 
-    toggleRegistration.mutate({ id: eventId });
+    toggleRegistration.mutate({ id: eventId, clubId });
   };
 
   const { data: memberType } = useQuery(

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -188,8 +188,7 @@ export const adminRouter = createTRPCRouter({
     .input(z.object({ id: z.string(), clubId: z.string() }))
     .mutation(async ({ input, ctx }) => {
       const event = await ctx.db.query.events.findFirst({
-        where: (e) =>
-          and(eq(e.id, input.id), eq(e.clubId, input.clubId)),
+        where: (e) => and(eq(e.id, input.id), eq(e.clubId, input.clubId)),
       });
 
       if (!event) {
@@ -208,9 +207,7 @@ export const adminRouter = createTRPCRouter({
           ),
         ctx.db
           .delete(events)
-          .where(
-            and(eq(events.id, input.id), eq(events.clubId, input.clubId)),
-          ),
+          .where(and(eq(events.id, input.id), eq(events.clubId, input.clubId))),
       ]);
 
       return { success: true };

--- a/src/server/api/routers/admin.ts
+++ b/src/server/api/routers/admin.ts
@@ -185,10 +185,11 @@ export const adminRouter = createTRPCRouter({
       }
     }),
   deleteEvent: adminProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: z.string(), clubId: z.string() }))
     .mutation(async ({ input, ctx }) => {
       const event = await ctx.db.query.events.findFirst({
-        where: (e) => eq(e.id, input.id),
+        where: (e) =>
+          and(eq(e.id, input.id), eq(e.clubId, input.clubId)),
       });
 
       if (!event) {
@@ -199,8 +200,17 @@ export const adminRouter = createTRPCRouter({
         callStorageAPI('DELETE', `${event.clubId}-event-${event.id}`),
         ctx.db
           .delete(userMetadataToEvents)
-          .where(eq(userMetadataToEvents.eventId, input.id)),
-        ctx.db.delete(events).where(eq(events.id, input.id)), // only place where event is fully deleted from DB
+          .where(
+            and(
+              eq(userMetadataToEvents.eventId, input.id),
+              eq(userMetadataToEvents.clubId, input.clubId),
+            ),
+          ),
+        ctx.db
+          .delete(events)
+          .where(
+            and(eq(events.id, input.id), eq(events.clubId, input.clubId)),
+          ),
       ]);
 
       return { success: true };

--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -82,6 +82,7 @@ const byNameSchema = z.object({
 });
 const joinLeaveSchema = z.object({
   id: z.string(),
+  clubId: z.string(),
 });
 
 export const eventRouter = createTRPCRouter({
@@ -353,7 +354,7 @@ export const eventRouter = createTRPCRouter({
     .input(joinLeaveSchema)
     .query(async ({ input, ctx }) => {
       if (!ctx.session) return null;
-      const eventId = input.id;
+      const { id: eventId, clubId } = input;
       const userId = ctx.session.user.id;
       return Boolean(
         await ctx.db.query.userMetadataToEvents.findFirst({
@@ -361,6 +362,7 @@ export const eventRouter = createTRPCRouter({
             and(
               eq(userMetadataToEvents.userId, userId),
               eq(userMetadataToEvents.eventId, eventId),
+              eq(userMetadataToEvents.clubId, clubId),
             ),
         }),
       );
@@ -370,13 +372,14 @@ export const eventRouter = createTRPCRouter({
     .query(async ({ input, ctx }) => {
       if (!ctx.session) return null;
 
-      const eventId = input.id;
+      const { id: eventId, clubId } = input;
       const userId = ctx.session.user.id;
       const result = await ctx.db.query.userMetadataToEvents.findFirst({
         where: (userMetadataToEvents) =>
           and(
             eq(userMetadataToEvents.userId, userId),
             eq(userMetadataToEvents.eventId, eventId),
+            eq(userMetadataToEvents.clubId, clubId),
           ),
       });
       return {
@@ -387,13 +390,14 @@ export const eventRouter = createTRPCRouter({
   toggleRegistration: protectedProcedure
     .input(joinLeaveSchema)
     .mutation(async ({ ctx, input }) => {
-      const eventId = input.id;
+      const { id: eventId, clubId } = input;
       const userId = ctx.session.user.id;
       const dataExists = await ctx.db.query.userMetadataToEvents.findFirst({
         where: (userMetadataToEvents) =>
           and(
             eq(userMetadataToEvents.userId, userId),
             eq(userMetadataToEvents.eventId, eventId),
+            eq(userMetadataToEvents.clubId, clubId),
           ),
       });
       if (dataExists) {
@@ -403,12 +407,13 @@ export const eventRouter = createTRPCRouter({
             and(
               eq(userMetadataToEvents.userId, userId),
               eq(userMetadataToEvents.eventId, eventId),
+              eq(userMetadataToEvents.clubId, clubId),
             ),
           );
       } else {
         await ctx.db
           .insert(userMetadataToEvents)
-          .values({ userId, eventId, registeredAt: new Date() });
+          .values({ userId, eventId, clubId, registeredAt: new Date() });
       }
       return dataExists;
     }),
@@ -459,7 +464,7 @@ export const eventRouter = createTRPCRouter({
           image: data.image,
           updatedAt: new Date(),
         })
-        .where(eq(events.id, id))
+        .where(and(eq(events.id, id), eq(events.clubId, input.clubId)))
         .returning({ id: events.id });
 
       if (res.length == 0)
@@ -470,10 +475,11 @@ export const eventRouter = createTRPCRouter({
       return res[0]?.id;
     }),
   delete: protectedProcedure
-    .input(z.object({ id: z.string() }))
+    .input(z.object({ id: z.string(), clubId: z.string() }))
     .mutation(async ({ input, ctx }) => {
       const event = await ctx.db.query.events.findFirst({
-        where: (e) => eq(e.id, input.id),
+        where: (e) =>
+          and(eq(e.id, input.id), eq(e.clubId, input.clubId)),
       });
 
       if (!event) {
@@ -491,7 +497,9 @@ export const eventRouter = createTRPCRouter({
       await ctx.db
         .update(events)
         .set({ status: 'deleted' })
-        .where(eq(events.id, input.id));
+        .where(
+          and(eq(events.id, input.id), eq(events.clubId, input.clubId)),
+        );
 
       return { success: true };
     }),

--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -478,8 +478,7 @@ export const eventRouter = createTRPCRouter({
     .input(z.object({ id: z.string(), clubId: z.string() }))
     .mutation(async ({ input, ctx }) => {
       const event = await ctx.db.query.events.findFirst({
-        where: (e) =>
-          and(eq(e.id, input.id), eq(e.clubId, input.clubId)),
+        where: (e) => and(eq(e.id, input.id), eq(e.clubId, input.clubId)),
       });
 
       if (!event) {
@@ -497,9 +496,7 @@ export const eventRouter = createTRPCRouter({
       await ctx.db
         .update(events)
         .set({ status: 'deleted' })
-        .where(
-          and(eq(events.id, input.id), eq(events.clubId, input.clubId)),
-        );
+        .where(and(eq(events.id, input.id), eq(events.clubId, input.clubId)));
 
       return { success: true };
     }),

--- a/src/server/db/migrations/20260419000000_events_composite_pk.sql
+++ b/src/server/db/migrations/20260419000000_events_composite_pk.sql
@@ -1,0 +1,35 @@
+-- Issue 611: Change events PK from (id) to (id, club_id)
+-- and add club_id to user_metadata_to_events for composite FK
+
+-- 1. Drop old FK from user_metadata_to_events → events(id)
+ALTER TABLE "user_metadata_to_events" DROP CONSTRAINT "user_metadata_to_events_event_id_events_id_fk";--> statement-breakpoint
+
+-- 2. Drop old PK on events
+ALTER TABLE "events" DROP CONSTRAINT "events_pkey";--> statement-breakpoint
+
+-- 3. Add composite PK on events (id, club_id)
+ALTER TABLE "events" ADD CONSTRAINT "events_id_club_id_pk" PRIMARY KEY ("id", "club_id");--> statement-breakpoint
+
+-- 4. Drop old PK on user_metadata_to_events
+ALTER TABLE "user_metadata_to_events" DROP CONSTRAINT "user_metadata_to_events_user_id_event_id_pk";--> statement-breakpoint
+
+-- 5. Add club_id column (nullable first for backfill)
+ALTER TABLE "user_metadata_to_events" ADD COLUMN "club_id" text;--> statement-breakpoint
+
+-- 6. Backfill club_id from events table
+UPDATE "user_metadata_to_events" AS um
+SET "club_id" = e."club_id"
+FROM "events" AS e
+WHERE um."event_id" = e."id";--> statement-breakpoint
+
+-- 7. Delete orphaned registrations that have no matching event
+DELETE FROM "user_metadata_to_events" WHERE "club_id" IS NULL;--> statement-breakpoint
+
+-- 8. Make club_id NOT NULL
+ALTER TABLE "user_metadata_to_events" ALTER COLUMN "club_id" SET NOT NULL;--> statement-breakpoint
+
+-- 9. Add new composite PK on user_metadata_to_events
+ALTER TABLE "user_metadata_to_events" ADD CONSTRAINT "user_metadata_to_events_user_id_event_id_club_id_pk" PRIMARY KEY ("user_id", "event_id", "club_id");--> statement-breakpoint
+
+-- 10. Add composite FK from user_metadata_to_events(event_id, club_id) → events(id, club_id)
+ALTER TABLE "user_metadata_to_events" ADD CONSTRAINT "user_metadata_to_events_event_id_club_id_events_id_club_id_fk" FOREIGN KEY ("event_id", "club_id") REFERENCES "public"."events"("id", "club_id") ON DELETE no action ON UPDATE no action;

--- a/src/server/db/migrations/meta/20260419000000_snapshot.json
+++ b/src/server/db/migrations/meta/20260419000000_snapshot.json
@@ -1,0 +1,1394 @@
+{
+  "id": "cf4ac951-7052-4c07-b8e6-08dcb11ef528",
+  "prevId": "bd2003f5-b728-4621-81ec-ea2d671ff3d5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.admin": {
+      "name": "admin",
+      "schema": "",
+      "columns": {
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "admin_userId_user_metadata_id_fk": {
+          "name": "admin_userId_user_metadata_id_fk",
+          "tableFrom": "admin",
+          "tableTo": "user_metadata",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.calendar_webhooks": {
+      "name": "calendar_webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiration": {
+          "name": "expiration",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "calendar_webhooks_club_id_club_id_fk": {
+          "name": "calendar_webhooks_club_id_club_id_fk",
+          "tableFrom": "calendar_webhooks",
+          "tableTo": "club",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.club": {
+      "name": "club",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "nanoid(20)"
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "founding_date": {
+          "name": "founding_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "approved": {
+          "name": "approved",
+          "type": "approved_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banner_image": {
+          "name": "banner_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "soc": {
+          "name": "soc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "page_views": {
+          "name": "page_views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_name": {
+          "name": "calendar_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_sync_token": {
+          "name": "calendar_sync_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_webhook_id": {
+          "name": "calendar_webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendar_webhook_expiration": {
+          "name": "calendar_webhook_expiration",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "club_size": {
+          "name": "club_size",
+          "type": "club_size",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calendarGoogleAccountId": {
+          "name": "calendarGoogleAccountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schools": {
+          "name": "schools",
+          "type": "school_enum[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::school_enum[]"
+        }
+      },
+      "indexes": {
+        "club_search_idx": {
+          "name": "club_search_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "alias",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "description",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tags",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "approved",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "bm25",
+          "with": {
+            "key_field": "id",
+            "text_fields": "'{\"tags\":{\"tokenizer\":{\"type\":\"keyword\"}},\"name\":{\"tokenizer\":{\"type\":\"default\",\"stemmer\":\"English\"}}}'",
+            "numeric_fields": "'{\"approved\":{\"fast\":true}}'"
+          }
+        },
+        "club_name": {
+          "name": "club_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "club_slug_unique": {
+          "name": "club_slug_unique",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "club_calendarGoogleAccountId_user_id_fk": {
+          "name": "club_calendarGoogleAccountId_user_id_fk",
+          "tableFrom": "club",
+          "tableTo": "user",
+          "columnsFrom": [
+            "calendarGoogleAccountId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contacts": {
+      "name": "contacts",
+      "schema": "",
+      "columns": {
+        "platform": {
+          "name": "platform",
+          "type": "platform",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contacts_club_id_club_id_fk": {
+          "name": "contacts_club_id_club_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "club",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "contacts_platform_club_id_pk": {
+          "name": "contacts_platform_club_id_pk",
+          "columns": [
+            "platform",
+            "club_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "nanoid(20)"
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "approved": {
+          "name": "approved",
+          "type": "status_enum",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'approved'"
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recurrence": {
+          "name": "recurrence",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurence_id": {
+          "name": "recurence_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "google": {
+          "name": "google",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "page_views": {
+          "name": "page_views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "calendar_id": {
+          "name": "calendar_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "events_club_id_club_id_fk": {
+          "name": "events_club_id_club_id_fk",
+          "tableFrom": "events",
+          "tableTo": "club",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "events_id_club_id_pk": {
+          "name": "events_id_club_id_pk",
+          "columns": [
+            "id",
+            "club_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.membership_forms": {
+      "name": "membership_forms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "membership_forms_club_id_club_id_fk": {
+          "name": "membership_forms_club_id_club_id_fk",
+          "tableFrom": "membership_forms",
+          "tableTo": "club",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.officers": {
+      "name": "officers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "officers_club_id_club_id_fk": {
+          "name": "officers_club_id_club_id_fk",
+          "tableFrom": "officers",
+          "tableTo": "club",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_ai_cache": {
+      "name": "user_ai_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clubMatch": {
+          "name": "clubMatch",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clubMatchLimit": {
+          "name": "clubMatchLimit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "responses": {
+          "name": "responses",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_metadata": {
+      "name": "user_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "major": {
+          "name": "major",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "minor": {
+          "name": "minor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "student_classification": {
+          "name": "student_classification",
+          "type": "student_classification",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Student'"
+        },
+        "graduation_date": {
+          "name": "graduation_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_metadata_to_clubs": {
+      "name": "user_metadata_to_clubs",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "member_type": {
+          "name": "member_type",
+          "type": "member_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_metadata_to_clubs_user_id_user_metadata_id_fk": {
+          "name": "user_metadata_to_clubs_user_id_user_metadata_id_fk",
+          "tableFrom": "user_metadata_to_clubs",
+          "tableTo": "user_metadata",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_metadata_to_clubs_club_id_club_id_fk": {
+          "name": "user_metadata_to_clubs_club_id_club_id_fk",
+          "tableFrom": "user_metadata_to_clubs",
+          "tableTo": "club",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_metadata_to_clubs_user_id_club_id_pk": {
+          "name": "user_metadata_to_clubs_user_id_club_id_pk",
+          "columns": [
+            "user_id",
+            "club_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_metadata_to_events": {
+      "name": "user_metadata_to_events",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_metadata_to_events_user_id_user_id_fk": {
+          "name": "user_metadata_to_events_user_id_user_id_fk",
+          "tableFrom": "user_metadata_to_events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_metadata_to_events_event_id_club_id_events_id_club_id_fk": {
+          "name": "user_metadata_to_events_event_id_club_id_events_id_club_id_fk",
+          "tableFrom": "user_metadata_to_events",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id",
+            "club_id"
+          ],
+          "columnsTo": [
+            "id",
+            "club_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_metadata_to_events_user_id_event_id_club_id_pk": {
+          "name": "user_metadata_to_events_user_id_event_id_club_id_pk",
+          "columns": [
+            "user_id",
+            "event_id",
+            "club_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.approved_enum": {
+      "name": "approved_enum",
+      "schema": "public",
+      "values": [
+        "approved",
+        "rejected",
+        "pending",
+        "deleted"
+      ]
+    },
+    "public.club_size": {
+      "name": "club_size",
+      "schema": "public",
+      "values": [
+        "1-10",
+        "10-50",
+        "50-200",
+        "200+"
+      ]
+    },
+    "public.school_enum": {
+      "name": "school_enum",
+      "schema": "public",
+      "values": [
+        "Harry W. Bass Jr. School of Arts, Humanities, and Technology",
+        "School of Behavioral and Brain Sciences",
+        "School of Economic, Political and Policy Sciences",
+        "Erik Jonsson School of Engineering and Computer Science",
+        "School of Interdisciplinary Studies",
+        "Naveen Jindal School of Management",
+        "School of Natural Sciences and Mathematics"
+      ]
+    },
+    "public.platform": {
+      "name": "platform",
+      "schema": "public",
+      "values": [
+        "discord",
+        "instagram",
+        "website",
+        "email",
+        "twitter",
+        "facebook",
+        "youtube",
+        "twitch",
+        "linkedIn",
+        "other"
+      ]
+    },
+    "public.status_enum": {
+      "name": "status_enum",
+      "schema": "public",
+      "values": [
+        "approved",
+        "rejected",
+        "pending",
+        "deleted"
+      ]
+    },
+    "public.member_type": {
+      "name": "member_type",
+      "schema": "public",
+      "values": [
+        "President",
+        "Officer",
+        "Member"
+      ]
+    },
+    "public.student_classification": {
+      "name": "student_classification",
+      "schema": "public",
+      "values": [
+        "Student",
+        "Graduate Student",
+        "Alum",
+        "Prospective Student",
+        "Faculty",
+        "Staff"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.used_tags": {
+      "columns": {
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "definition": "\n  SELECT \n    tag, \n    COUNT(*) as count, \n    ROW_NUMBER() OVER (ORDER BY COUNT(*) DESC)::integer as id \n  FROM (\n    SELECT UNNEST(\"club\".\"tags\") as tag FROM \"club\"\n  ) sub \n  GROUP BY tag \n  ORDER BY count DESC\n",
+      "name": "used_tags",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": true
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/server/db/migrations/meta/_journal.json
+++ b/src/server/db/migrations/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1775511351494,
       "tag": "20260406213551_conscious_silver_sable",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1776556800000,
+      "tag": "20260419000000_events_composite_pk",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/db/schema/events.ts
+++ b/src/server/db/schema/events.ts
@@ -4,6 +4,7 @@ import {
   integer,
   pgEnum,
   pgTable,
+  primaryKey,
   text,
   timestamp,
 } from 'drizzle-orm/pg-core';
@@ -17,29 +18,33 @@ export const statusEnum = pgEnum('status_enum', [
   'deleted',
 ]);
 
-export const events = pgTable('events', {
-  id: text('id')
-    .default(sql`nanoid(20)`)
-    .primaryKey(),
-  clubId: text('club_id')
-    .notNull()
-    .references(() => club.id, { onDelete: 'cascade' }),
-  name: text('name').notNull(),
-  description: text('description').default('').notNull(),
-  status: statusEnum('approved').notNull().default('approved'),
-  startTime: timestamp('start_time').notNull(),
-  endTime: timestamp('end_time').notNull(),
-  recurrence: text('recurrence'),
-  recurenceId: text('recurence_id'),
-  google: boolean().default(false).notNull(),
-  etag: text(),
-  location: text('location').default('').notNull(),
-  image: text('image'),
-  createdAt: timestamp('created_at').notNull().defaultNow(),
-  updatedAt: timestamp('updated_at').notNull().defaultNow(),
-  pageViews: integer('page_views').notNull().default(0),
-  calendarId: text('calendar_id'),
-});
+export const events = pgTable(
+  'events',
+  {
+    id: text('id')
+      .default(sql`nanoid(20)`)
+      .notNull(),
+    clubId: text('club_id')
+      .notNull()
+      .references(() => club.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    description: text('description').default('').notNull(),
+    status: statusEnum('approved').notNull().default('approved'),
+    startTime: timestamp('start_time').notNull(),
+    endTime: timestamp('end_time').notNull(),
+    recurrence: text('recurrence'),
+    recurenceId: text('recurence_id'),
+    google: boolean().default(false).notNull(),
+    etag: text(),
+    location: text('location').default('').notNull(),
+    image: text('image'),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    pageViews: integer('page_views').notNull().default(0),
+    calendarId: text('calendar_id'),
+  },
+  (t) => [primaryKey({ columns: [t.id, t.clubId] })],
+);
 
 export const eventsRelation = relations(events, ({ one, many }) => ({
   club: one(club, { fields: [events.clubId], references: [club.id] }),

--- a/src/server/db/schema/users.ts
+++ b/src/server/db/schema/users.ts
@@ -1,6 +1,7 @@
 import { relations } from 'drizzle-orm';
 import {
   date,
+  foreignKey,
   integer,
   jsonb,
   pgEnum,
@@ -64,12 +65,17 @@ export const userMetadataToEvents = pgTable(
     userId: text('user_id')
       .notNull()
       .references(() => user.id, { onDelete: 'cascade' }),
-    eventId: text('event_id')
-      .notNull()
-      .references(() => events.id, { onDelete: 'no action' }),
+    eventId: text('event_id').notNull(),
+    clubId: text('club_id').notNull(),
     registeredAt: timestamp('registered_at').defaultNow().notNull(),
   },
-  (t) => [primaryKey({ columns: [t.userId, t.eventId] })],
+  (t) => [
+    primaryKey({ columns: [t.userId, t.eventId, t.clubId] }),
+    foreignKey({
+      columns: [t.eventId, t.clubId],
+      foreignColumns: [events.id, events.clubId],
+    }).onDelete('no action'),
+  ],
 );
 
 export const userMetadataRelation = relations(
@@ -101,8 +107,8 @@ export const userMetadataToEventsRelations = relations(
   userMetadataToEvents,
   ({ one }) => ({
     event: one(events, {
-      fields: [userMetadataToEvents.eventId],
-      references: [events.id],
+      fields: [userMetadataToEvents.eventId, userMetadataToEvents.clubId],
+      references: [events.id, events.clubId],
     }),
     user: one(userMetadata, {
       fields: [userMetadataToEvents.userId],

--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -135,7 +135,12 @@ export async function syncCalendar(
           await tx
             .update(eventTable)
             .set({ status: 'deleted' })
-            .where(inArray(eventTable.id, deletedIds));
+            .where(
+              and(
+                inArray(eventTable.id, deletedIds),
+                eq(eventTable.clubId, clubId),
+              ),
+            );
         }
         try {
           if (newOrUpdated.length > 0) {
@@ -143,7 +148,7 @@ export async function syncCalendar(
               .insert(eventTable)
               .values(newOrUpdated.map((e) => generateEvent(clubId, e)))
               .onConflictDoUpdate({
-                target: eventTable.id,
+                target: [eventTable.id, eventTable.clubId],
                 set: buildConflictUpdateColumns(eventTable, [
                   'name',
                   'description',


### PR DESCRIPTION
## What's the problem?

Right now the `events` table uses just `id` as its primary key. When two clubs link the **same** Google Calendar, the calendar sync tries to insert the same event ID for both clubs and one of them loses. Whichever club syncs second either overwrites the first club's event or gets a conflict error.

## What does this PR do?

Changes the events primary key from `(id)` to `(id, club_id)`, so the same Google Calendar event can exist under multiple clubs without stepping on each other.

### Schema

- **`events`** table: primary key is now `(id, club_id)` instead of just `(id)`
- **`user_metadata_to_events`** table: added a `club_id` column, primary key is now `(user_id, event_id, club_id)`, and the foreign key points to `events(id, club_id)` instead of just `events(id)`

### Backend (tRPC routers + calendar sync)

- **Event router**: `joinedEvent`, `registerState`, `toggleRegistration`, `update`, and `delete` all now require and filter by `clubId`
- **Admin router**: `deleteEvent` now requires `clubId` and scopes both the registration cleanup and the event delete by `(id, club_id)`
- **Calendar sync** (`calendar.ts`): upsert conflict target changed to `[id, clubId]`, and soft-deletes of cancelled events are now scoped by `clubId` so one club's sync can't accidentally mark another club's copy as deleted

### Frontend

- **EventRegisterButton**: passes `clubId` to `registerState`, `toggleRegistration`, and all cache key references
- **EventDeleteButton**: passes `clubId` alongside `id` when calling delete

### Migration

The migration (`20260419000000_events_composite_pk.sql`) does this in order:
1. Drops the old FK from `user_metadata_to_events` to `events`
2. Swaps the events PK from `(id)` to `(id, club_id)`
3. Adds `club_id` to `user_metadata_to_events` (nullable at first)
4. Backfills `club_id` from the `events` table
5. Deletes any orphaned registrations that don't match an event
6. Makes `club_id` NOT NULL
7. Sets the new composite PK and FK


Closes #611