### PR TITLE
fix: enforce google flag on event update mutation

### DIFF
--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -462,12 +462,30 @@ export const eventRouter = createTRPCRouter({
         .where(and(eq(events.id, id), eq(events.google, false)))
         .returning({ id: events.id });
 
-      if (res.length === 0)
-        throw new TRPCError({
-          code: 'FORBIDDEN',
-          message:
-            'Cannot edit a Google Calendar event directly, or event not found.',
+      if (res.length === 0) {
+        const existing = await ctx.db.query.events.findFirst({
+          where: (e) => eq(e.id, id),
         });
+
+        if (!existing) {
+          throw new TRPCError({
+            code: 'NOT_FOUND',
+            message: 'Event not found.',
+          });
+        }
+
+        if (existing.google) {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: 'Cannot edit a Google Calendar event directly.',
+          });
+        }
+
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to update event.',
+        });
+      }
       return res[0]?.id;
     }),
   delete: protectedProcedure

--- a/src/server/api/routers/event.ts
+++ b/src/server/api/routers/event.ts
@@ -459,13 +459,14 @@ export const eventRouter = createTRPCRouter({
           image: data.image,
           updatedAt: new Date(),
         })
-        .where(eq(events.id, id))
+        .where(and(eq(events.id, id), eq(events.google, false)))
         .returning({ id: events.id });
 
-      if (res.length == 0)
+      if (res.length === 0)
         throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'Failed to update event',
+          code: 'FORBIDDEN',
+          message:
+            'Cannot edit a Google Calendar event directly, or event not found.',
         });
       return res[0]?.id;
     }),


### PR DESCRIPTION
## Summary
Closes #683

- Adds `eq(events.google, false)` to the `.where()` clause in the `event.update` mutation so Google Calendar synced events cannot be modified through the API
- Previously only the frontend hid the edit button for GCal events; the backend accepted edits regardless

