### PR TITLE
Panel banner to update collaborators

### DIFF
--- a/src/app/manage/[slug]/(dashboard)/(forms)/Collaborators.tsx
+++ b/src/app/manage/[slug]/(dashboard)/(forms)/Collaborators.tsx
@@ -128,6 +128,7 @@ const Collaborators = ({
       }}
     >
       <Panel
+        id="collaborators"
         heading="Collaborators"
         description={
           <>

--- a/src/app/manage/[slug]/(dashboard)/ClubManageForm.tsx
+++ b/src/app/manage/[slug]/(dashboard)/ClubManageForm.tsx
@@ -10,6 +10,7 @@ import Details from './(forms)/Details';
 import MembershipForms from './(forms)/MembershipForms';
 import Officers from './(forms)/Officers';
 import Slug from './(forms)/Slug';
+import LeadershipChange from './LeadershipChange';
 import NotApproved from './NotApproved';
 import Resources from './Resources';
 
@@ -56,6 +57,12 @@ const ClubManageForm = async ({
   return (
     <div className="flex flex-col gap-8 w-full max-w-6xl">
       {club.approved !== 'approved' && <NotApproved status={club.approved} />}
+      {/*TODO: Update range to display banner for a month before the semester ends and until the next semester starts*/}
+      {club.approved === 'approved' &&
+        (club.updatedAt == null || club.updatedAt < new Date(2026, 4, 5)) &&
+        new Date() < new Date(2026, 7, 24) && (
+          <LeadershipChange clubId={club.id} />
+        )}
       <Details club={club} />
       <Calendar
         club={club}

--- a/src/app/manage/[slug]/(dashboard)/LeadershipChange.tsx
+++ b/src/app/manage/[slug]/(dashboard)/LeadershipChange.tsx
@@ -80,7 +80,7 @@ const LeadershipChange = ({ clubId }: { clubId: string }) => {
         contentText={
           <div className="flex flex-col gap-2">
             <p>
-              Confirm you've added everybody in your organization who needs
+              Confirm you&apos;ve added everybody in your organization who needs
               access to UTD Clubs next semester.
             </p>
             <p>

--- a/src/app/manage/[slug]/(dashboard)/LeadershipChange.tsx
+++ b/src/app/manage/[slug]/(dashboard)/LeadershipChange.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import CheckIcon from '@mui/icons-material/Check';
+import GppMaybeIcon from '@mui/icons-material/GppMaybe';
+import { Button, Collapse } from '@mui/material';
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+import Panel from '@src/components/common/Panel';
+import Confirmation from '@src/components/Confirmation';
+import { setSnackbar, SnackbarPresets } from '@src/components/global/Snackbar';
+import { useTRPC } from '@src/trpc/react';
+
+const LeadershipChange = ({ clubId }: { clubId: string }) => {
+  const [openConfirmation, setOpenConfirmation] = useState(false);
+  const [showPanel, setShowPanel] = useState(true);
+
+  const api = useTRPC();
+  const setUpdatedAt = useMutation(
+    api.club.edit.setUpdatedAt.mutationOptions({
+      onSuccess: () => {
+        setSnackbar(SnackbarPresets.saved);
+        setOpenConfirmation(false);
+        setShowPanel(false);
+      },
+      onError: (error) => {
+        setSnackbar(SnackbarPresets.errorMessage(error.message));
+      },
+    }),
+  );
+
+  return (
+    <>
+      <Collapse in={showPanel}>
+        <Panel
+          className="bg-red-100 dark:bg-red-950 border border-red-500 dark:border-red-700"
+          startAdornment={<GppMaybeIcon />}
+          heading="Update your collaborators for next semester."
+        >
+          <div className="flex flex-col gap-4 px-2">
+            <p>
+              If your organization has had a change in leadership, have your
+              successors sign in to UTD Clubs, then add them as admins or
+              collaborators{' '}
+              <a
+                href="#collaborators"
+                className="text-royal dark:text-cornflower-300 underline"
+              >
+                near the bottom of the page
+              </a>
+              .
+            </p>
+            <div className="flex flex-col items-center gap-2">
+              <Button
+                variant="contained"
+                className="normal-case"
+                startIcon={<CheckIcon />}
+                size="large"
+                onClick={() => setOpenConfirmation(true)}
+              >
+                I have added my organizations new leadership to manage this
+                listing
+              </Button>
+              <Button
+                variant="contained"
+                className="normal-case"
+                startIcon={<CheckIcon />}
+                size="large"
+                onClick={() => setOpenConfirmation(true)}
+              >
+                My organization has no leadership changes
+              </Button>
+            </div>
+          </div>
+        </Panel>
+      </Collapse>
+      <Confirmation
+        open={openConfirmation}
+        onClose={() => setOpenConfirmation(false)}
+        title="Confirm Collaborators Are up to Date"
+        contentText="Confirm that every member of your organization that needs access to UTD Clubs for the next semester has been given access. We will not email you or any other collaborators reminders for next semester after this."
+        confirmText="Confirm"
+        confirmColor="primary"
+        onConfirm={() => setUpdatedAt.mutate({ id: clubId })}
+        loading={setUpdatedAt.isPending}
+      />
+    </>
+  );
+};
+
+export default LeadershipChange;

--- a/src/app/manage/[slug]/(dashboard)/LeadershipChange.tsx
+++ b/src/app/manage/[slug]/(dashboard)/LeadershipChange.tsx
@@ -39,8 +39,8 @@ const LeadershipChange = ({ clubId }: { clubId: string }) => {
           <div className="flex flex-col gap-4 px-2">
             <p>
               If your organization has had a change in leadership, have your
-              successors sign in to UTD Clubs, then add them as admins or
-              collaborators{' '}
+              successors create an account on UTD Clubs, then add them as admins
+              or collaborators{' '}
               <a
                 href="#collaborators"
                 className="text-royal dark:text-cornflower-300 underline"
@@ -57,8 +57,8 @@ const LeadershipChange = ({ clubId }: { clubId: string }) => {
                 size="large"
                 onClick={() => setOpenConfirmation(true)}
               >
-                I have added my organizations new leadership to manage this
-                listing
+                I have added my organization&apos;s new leadership to manage
+                this listing
               </Button>
               <Button
                 variant="contained"
@@ -76,18 +76,16 @@ const LeadershipChange = ({ clubId }: { clubId: string }) => {
       <Confirmation
         open={openConfirmation}
         onClose={() => setOpenConfirmation(false)}
-        title="Confirm Collaborators Are up to Date"
+        title="Confirm Collaborators are up to date"
         contentText={
-          <div className="flex flex-col gap-2">
-            <p>
-              Confirm you&apos;ve added everybody in your organization who needs
-              access to UTD Clubs next semester.
-            </p>
-            <p>
-              You will not be emailed or reminded to do this again until the end
-              of next semester.
-            </p>
-          </div>
+          <>
+            Confirm you&apos;ve added everybody in your organization who needs
+            access to UTD Clubs next semester.
+            <br />
+            <br />
+            You will not be emailed or reminded to do this again until the end
+            of next semester.
+          </>
         }
         confirmText="Confirm"
         confirmColor="primary"

--- a/src/app/manage/[slug]/(dashboard)/LeadershipChange.tsx
+++ b/src/app/manage/[slug]/(dashboard)/LeadershipChange.tsx
@@ -77,7 +77,18 @@ const LeadershipChange = ({ clubId }: { clubId: string }) => {
         open={openConfirmation}
         onClose={() => setOpenConfirmation(false)}
         title="Confirm Collaborators Are up to Date"
-        contentText="Confirm that every member of your organization that needs access to UTD Clubs for the next semester has been given access. We will not email you or any other collaborators reminders for next semester after this."
+        contentText={
+          <div className="flex flex-col gap-2">
+            <p>
+              Confirm you've added everybody in your organization who needs
+              access to UTD Clubs next semester.
+            </p>
+            <p>
+              You will not be emailed or reminded to do this again until the end
+              of next semester.
+            </p>
+          </div>
+        }
         confirmText="Confirm"
         confirmColor="primary"
         onConfirm={() => setUpdatedAt.mutate({ id: clubId })}

--- a/src/server/api/routers/clubEdit.ts
+++ b/src/server/api/routers/clubEdit.ts
@@ -35,6 +35,10 @@ async function isUserPresident(userId: string, clubId: string) {
   return officer?.memberType == 'President';
 }
 
+const byIdSchema = z.object({
+  id: z.string().default(''),
+});
+
 const editContactSchema = z.object({
   clubId: z.string(),
   deleted: selectContact.shape.platform.array(),
@@ -132,6 +136,21 @@ export const clubEditRouter = createTRPCRouter({
         .returning();
 
       return updatedClub[0];
+    }),
+  setUpdatedAt: protectedProcedure
+    .input(byIdSchema)
+    .mutation(async ({ input, ctx }) => {
+      const isOfficer = await isUserOfficer(ctx.session.user.id, input.id);
+      if (!isOfficer) throw new TRPCError({ code: 'UNAUTHORIZED' });
+
+      await ctx.db
+        .update(club)
+        .set({
+          updatedAt: new Date(),
+        })
+        .where(eq(club.id, input.id));
+
+      return { success: true };
     }),
   contacts: protectedProcedure
     .input(editContactSchema)

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -50,6 +50,7 @@
   body {
     padding: 0;
     margin: 0;
+    scroll-behavior: smooth;
   }
 
   a {


### PR DESCRIPTION
Banner will show up for approved clubs that haven't been updated since May 6th (when I sent the first email reminder org admins to update their leadership) and until the start of next semester.

This will allow @AbhiramTadepalli to query the DB for users that are a collaborator or admin of a club with an updatedAt date before I sent the first leadership change email. And keep emailing these people to add their new leadership or click the "no changes" button on Clubs.

https://github.com/user-attachments/assets/28b08d34-5ac2-43ae-8d8a-0248246c515f

I'm adding a follow up issue (waiting on https://github.com/UTDNebula/nebula-api/issues/303) to un-hardcode the dates in the code so it always shows up from a month before a semester ends to the start of the next semester