### PR TITLE
Remove overly inclusive import path from tsconfig

### DIFF
--- a/src/app/manage/[slug]/(dashboard)/(forms)/Details.tsx
+++ b/src/app/manage/[slug]/(dashboard)/(forms)/Details.tsx
@@ -3,7 +3,6 @@
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
-import { useUploadToUploadURL } from 'src/utils/uploadImage';
 import type z from 'zod';
 import ClubTagAutocomplete from '@src/components/club/ClubTagAutocomplete';
 import Panel, { PanelSkeleton } from '@src/components/common/Panel';
@@ -16,6 +15,7 @@ import { useTRPC } from '@src/trpc/react';
 import { useAppForm } from '@src/utils/form';
 import { editClubFormSchema, schools } from '@src/utils/formSchemas';
 import { addVersionToImage } from '@src/utils/imageCacheBust';
+import { useUploadToUploadURL } from '@src/utils/uploadImage';
 
 type DetailsProps = {
   club: SelectClub;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
+import gradientBG from '@public/images/landingGradient.png';
+import planetsDoodle from '@public/images/PlanetsDoodle.png';
 import Image from 'next/image';
-import gradientBG from 'public/images/landingGradient.png';
-import planetsDoodle from 'public/images/PlanetsDoodle.png';
 import { AllTags } from '@src/components/AllTags';
 import ClubDirectoryGrid from '@src/components/club/directory/ClubDirectoryGrid';
 import Header from '@src/components/header/Header';

--- a/src/components/admin/DebounceInput.tsx
+++ b/src/components/admin/DebounceInput.tsx
@@ -1,6 +1,6 @@
 import TextField, { TextFieldProps } from '@mui/material/TextField';
 import { useEffect, useState } from 'react';
-import useDebounce from 'src/utils/useDebounce';
+import useDebounce from '@src/utils/useDebounce';
 
 type Props = {
   value: string | number;

--- a/src/components/events/EventForm.tsx
+++ b/src/components/events/EventForm.tsx
@@ -6,7 +6,6 @@ import { useStore } from '@tanstack/react-form';
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useMemo } from 'react';
-import { useUploadToUploadURL } from 'src/utils/uploadImage';
 import Panel, { PanelSkeleton } from '@src/components/common/Panel';
 import { setSnackbar, SnackbarPresets } from '@src/components/global/Snackbar';
 import FormImage from '@src/components/manage/form/FormImage';
@@ -19,6 +18,7 @@ import {
   editEventFormSchema,
 } from '@src/utils/formSchemas';
 import { addVersionToImage } from '@src/utils/imageCacheBust';
+import { useUploadToUploadURL } from '@src/utils/uploadImage';
 import EventCard, { EventCardSkeleton } from './EventCard';
 
 type EventFormProps =

--- a/src/components/header/BaseHeader.tsx
+++ b/src/components/header/BaseHeader.tsx
@@ -3,9 +3,9 @@
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import SearchIcon from '@mui/icons-material/Search';
 import { IconButton } from '@mui/material';
+import gradientBG from '@public/images/landingGradient.png';
 import Image from 'next/image';
 import Link from 'next/link';
-import gradientBG from 'public/images/landingGradient.png';
 import { createContext, useContext, useState, type ReactNode } from 'react';
 import { UTDClubsLogoStandalone } from '@src/icons/UTDClubsLogo';
 import { ProfileDropDown } from './ProfileDropDown';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "incremental": true,
     "noUncheckedIndexedAccess": true,
     "paths": {
-      "@src/*": ["./src/*"]
+      "@src/*": ["./src/*"],
+      "@public/*": ["./public/*"]
     },
     "plugins": [
       {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,6 @@
     "incremental": true,
     "noUncheckedIndexedAccess": true,
     "paths": {
-      "*": ["./*"],
       "@src/*": ["./src/*"]
     },
     "plugins": [


### PR DESCRIPTION
Hotfix to remove the entry `"*": ["./*"]` from `compilerOptions.paths` in `tsconfig.json` because it was too inclusive and supplanted the `@src/*` entry (thus meaning VS Code would suggest verbose import statements)

Also changed `public/` imports to `@public/`

Something I wanna do in the future: Replace all `@src/` imports with `@/` because ngl it's cleaner and that's how Trends does it