### PR TITLE
Make /events/calendar show all events

### DIFF
--- a/src/app/community/calendar/page.tsx
+++ b/src/app/community/calendar/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import EventCalendar from '@/systems/events/calendar/EventCalendar';
+import RegisteredEventsCalendar from '@/systems/events/calendar/calendars/RegisteredEventsCalendar';
 
 export const metadata: Metadata = {
   title: 'My Event Calendar | My Community',
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
 };
 
 const CalendarPage = () => {
-  return <EventCalendar />;
+  return <RegisteredEventsCalendar />;
 };
 
 export default CalendarPage;

--- a/src/app/events/(directory)/calendar/page.tsx
+++ b/src/app/events/(directory)/calendar/page.tsx
@@ -1,24 +1,14 @@
 import { Alert } from '@mui/material';
-import { headers } from 'next/headers';
-import { redirect } from 'next/navigation';
-import { signInRoute } from '@/lib/utils/redirect';
-import { auth } from '@/server/auth';
-import EventCalendar from '@/systems/events/calendar/EventCalendar';
+import AllEventsCalendar from '@/systems/events/calendar/calendars/AllEventsCalendar';
 
 export default async function CalendarPage() {
-  const session = await auth.api.getSession({ headers: await headers() });
-
-  if (!session) {
-    redirect(await signInRoute('events/calendar'));
-  }
-
   return (
     <>
       <Alert severity="info" className="mt-4">
         This calendar only shows events you have registered for. This will be
         resolved in the future.
       </Alert>
-      <EventCalendar />
+      <AllEventsCalendar />
     </>
   );
 }

--- a/src/app/events/(directory)/calendar/page.tsx
+++ b/src/app/events/(directory)/calendar/page.tsx
@@ -1,4 +1,6 @@
+import Skeleton from '@mui/material/Skeleton';
 import { Metadata } from 'next';
+import { Suspense } from 'react';
 import AllEventsCalendar from '@/systems/events/calendar/calendars/AllEventsCalendar';
 
 export const metadata: Metadata = {
@@ -14,5 +16,9 @@ export const metadata: Metadata = {
 };
 
 export default async function CalendarPage() {
-  return <AllEventsCalendar />;
+  return (
+    <Suspense fallback={<Skeleton variant="rectangular" height={512} />}>
+      <AllEventsCalendar />
+    </Suspense>
+  );
 }

--- a/src/app/events/(directory)/calendar/page.tsx
+++ b/src/app/events/(directory)/calendar/page.tsx
@@ -1,14 +1,18 @@
-import { Alert } from '@mui/material';
+import { Metadata } from 'next';
 import AllEventsCalendar from '@/systems/events/calendar/calendars/AllEventsCalendar';
 
+export const metadata: Metadata = {
+  title: 'Events Calendar',
+  description: 'The calendar with every event at UTD.',
+  alternates: {
+    canonical: 'https://clubs.utdnebula.com/events/calendar',
+  },
+  openGraph: {
+    url: 'https://clubs.utdnebula.com/events/calendar',
+    description: 'The calendar with every event at UTD.',
+  },
+};
+
 export default async function CalendarPage() {
-  return (
-    <>
-      <Alert severity="info" className="mt-4">
-        This calendar only shows events you have registered for. This will be
-        resolved in the future.
-      </Alert>
-      <AllEventsCalendar />
-    </>
-  );
+  return <AllEventsCalendar />;
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -5,8 +5,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   // Fetch all clubs and events
   const [clubs, events] = await Promise.all([
     api.club.all(),
-    api.event.byDateRange({
-      endTime: new Date(new Date().setFullYear(new Date().getFullYear() + 1)), // 1 year later
+    api.event.findByDateRange({
+      dateEnd: new Date(new Date().setFullYear(new Date().getFullYear() + 1)), // 1 year later
     }),
   ]);
 

--- a/src/server/api/routers/event/eventPublicRouter.ts
+++ b/src/server/api/routers/event/eventPublicRouter.ts
@@ -37,10 +37,10 @@ import { temporalDeixisCustomDateSentinelValue } from '@/systems/events/director
 import { eventIdSchema } from '../baseSchemas';
 import {
   byClubIdSchema,
-  byDateRangeSchema,
   byNameSchema,
   clubUpcomingEventsSchema,
   countSchema,
+  findByDateRangeSchema,
   findByDateSchema,
   findByFilterSchema,
 } from './inputSchemas';
@@ -137,32 +137,57 @@ const eventPublicRouter = createTRPCRouter({
         throw e;
       }
     }),
-  byDateRange: publicProcedure
-    .input(byDateRangeSchema)
+  findByDateRange: publicProcedure
+    .input(findByDateRangeSchema)
     .query(async ({ input, ctx }) => {
-      const { startTime, endTime } = input;
+      const { dateStart, dateEnd, includeUserEvents } = input;
+      const userId = ctx.session?.user.id;
+
+      // Include events from clubs the user is a member of, even if the club isn't approved
+      const joinedClubsSubquery =
+        includeUserEvents && userId
+          ? ctx.db
+              .select()
+              .from(userMetadataToClubs)
+              .where(
+                and(
+                  eq(userMetadataToClubs.clubId, events.clubId),
+                  eq(userMetadataToClubs.userId, userId),
+                  inArray(userMetadataToClubs.memberType, [
+                    'Member',
+                    'Officer',
+                    'President',
+                  ]),
+                ),
+              )
+          : undefined;
 
       try {
-        const events = await ctx.db.query.events.findMany({
-          where: (event) => {
-            return and(
-              eq(event.status, 'approved'),
-              or(
-                startTime ? gte(event.startTime, startTime) : undefined,
-                endTime ? lte(event.endTime, endTime) : undefined,
-              ),
-            );
-          },
-          with: {
-            club: true,
-          },
-        });
+        const query = ctx.db
+          .select({
+            events,
+            club,
+            isClubMember: joinedClubsSubquery
+              ? exists(joinedClubsSubquery)
+              : sql<boolean>`false`,
+          })
+          .from(events)
+          .leftJoin(club, eq(events.clubId, club.id))
+          .where(({ events }) =>
+            and(
+              eq(events.status, 'approved'),
+              dateStart ? gte(events.startTime, dateStart) : undefined,
+              dateEnd ? lte(events.endTime, dateEnd) : undefined,
+            ),
+          );
 
-        const approvedEvents = events.filter(
-          (e) => e.club.approved === 'approved',
-        );
+        const results = await query;
 
-        return approvedEvents;
+        const foundEvents = results
+          .filter((r) => r.isClubMember || r.club?.approved === 'approved') // Approved clubs
+          .map((r) => ({ ...r.events, club: r.club! })); // Map to correct format
+
+        return foundEvents;
       } catch (e) {
         console.error(e);
 

--- a/src/server/api/routers/event/inputSchemas.ts
+++ b/src/server/api/routers/event/inputSchemas.ts
@@ -36,9 +36,13 @@ export const clubUpcomingEventsSchema = clubIdSchema.extend({
   currentTime: z.date().optional(),
 });
 
-export const byDateRangeSchema = z.object({
-  startTime: z.date().optional(),
-  endTime: z.date().optional(),
+export const findByDateRangeSchema = z.object({
+  /** If omitted, includes all events from past */
+  dateStart: z.date().optional(),
+  /** If omitted, includes all events into future */
+  dateEnd: z.date().optional(),
+  /** Whether to include events from the user's clubs */
+  includeUserEvents: z.boolean().default(false).optional(),
 });
 
 export const findByFilterSchema = z.object({

--- a/src/systems/events/calendar/EventCalendar.tsx
+++ b/src/systems/events/calendar/EventCalendar.tsx
@@ -19,15 +19,13 @@ import {
   type EventClickArgs,
   type PopupOpenEventArgs,
 } from '@syncfusion/ej2-schedule';
-import { useQuery } from '@tanstack/react-query';
 import { isSameDay, startOfDay } from 'date-fns';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { getRangeForView, type CalendarRange } from '@/lib/utils/calendarRange';
 import { createParamSetter } from '@/lib/utils/searchParams';
 import EventCard from '@/systems/events/EventCard';
-import { useTRPC } from '@/trpc/react';
 import { type RouterOutputs } from '@/trpc/shared';
 import {
   calendarParamsSchema,
@@ -48,7 +46,22 @@ const SCHEDULE_FIELDS = {
 
 export const setCalendarParams = createParamSetter<CalendarParamsSchema>();
 
-const EventCalendar = () => {
+type SelectEventWithClub =
+  RouterOutputs['user']['events']['getRegisteredEventsByRange'][number];
+
+type EventCalendarProps = {
+  events: SelectEventWithClub[];
+  onMount?: (range: CalendarRange) => void;
+  onChange?: (range: CalendarRange) => void;
+  isFetching?: boolean;
+};
+
+const EventCalendar = ({
+  events,
+  onMount,
+  onChange,
+  isFetching,
+}: EventCalendarProps) => {
   const searchParams = useSearchParams();
   const params = calendarParamsSchema.parse(Object.fromEntries(searchParams));
 
@@ -67,19 +80,12 @@ const EventCalendar = () => {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [hoverAnchorEl, setHoverAnchorEl] = useState<Element | null>(null);
   const [hoverEvent, setHoverEvent] = useState<RegisteredEvent | null>(null);
-  const [range, setRange] = useState<CalendarRange>(() =>
-    getRangeForView(initialView, initialDate),
-  );
-
-  const api = useTRPC();
   const router = useRouter();
 
-  const { data: events = [], isFetching } = useQuery(
-    api.user.events.getRegisteredEventsByRange.queryOptions(range, {
-      staleTime: 30_000,
-      refetchOnWindowFocus: false,
-    }),
-  );
+  useEffect(() => {
+    onMount?.(getRangeForView(initialView, initialDate));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const eventMap = useMemo(
     () => new Map(events.map((e) => [e.id, e])),
@@ -146,7 +152,7 @@ const EventCalendar = () => {
         params.set('view', view);
       });
     }
-    setRange(getRangeForView(view, new Date(anchor)));
+    onChange?.(getRangeForView(view, new Date(anchor)));
   };
 
   const clearHover = () => {

--- a/src/systems/events/calendar/calendars/AllEventsCalendar.tsx
+++ b/src/systems/events/calendar/calendars/AllEventsCalendar.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import EventCalendar from '../EventCalendar';
+import { useTRPC } from '@/trpc/react';
+import { useState } from 'react';
+import { byDateRangeSchema } from '@/server/api/routers/event/inputSchemas';
+import { z } from 'zod';
+import { CalendarRange } from '@/lib/utils/calendarRange';
+
+export default function AllEventsCalendar() {
+  const api = useTRPC();
+
+  const [range, setRange] = useState<z.infer<typeof byDateRangeSchema>>(() => ({
+    startTime: new Date(),
+    endTime: new Date(),
+  }));
+
+  const { data: events = [], isFetching } = useQuery(
+    api.event.byDateRange.queryOptions(range, {
+      staleTime: 30_000,
+      refetchOnWindowFocus: false,
+    }),
+  );
+
+  const updateRange = (range: CalendarRange) => {
+    setRange({
+      startTime: new Date(range.startDate),
+      endTime: new Date(range.endDate),
+    });
+  };
+
+  return (
+    <EventCalendar
+      events={events}
+      onMount={updateRange}
+      onChange={updateRange}
+      isFetching={isFetching}
+    />
+  );
+}

--- a/src/systems/events/calendar/calendars/AllEventsCalendar.tsx
+++ b/src/systems/events/calendar/calendars/AllEventsCalendar.tsx
@@ -1,32 +1,37 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import EventCalendar from '../EventCalendar';
-import { useTRPC } from '@/trpc/react';
 import { useState } from 'react';
-import { byDateRangeSchema } from '@/server/api/routers/event/inputSchemas';
 import { z } from 'zod';
 import { CalendarRange } from '@/lib/utils/calendarRange';
+import { findByDateRangeSchema } from '@/server/api/routers/event/inputSchemas';
+import { useTRPC } from '@/trpc/react';
+import EventCalendar from '../EventCalendar';
 
 export default function AllEventsCalendar() {
   const api = useTRPC();
 
-  const [range, setRange] = useState<z.infer<typeof byDateRangeSchema>>(() => ({
-    startTime: new Date(),
-    endTime: new Date(),
-  }));
+  const [range, setRange] = useState<z.infer<typeof findByDateRangeSchema>>(
+    () => ({
+      dateStart: new Date(),
+      dateEnd: new Date(),
+    }),
+  );
 
   const { data: events = [], isFetching } = useQuery(
-    api.event.byDateRange.queryOptions(range, {
-      staleTime: 30_000,
-      refetchOnWindowFocus: false,
-    }),
+    api.event.findByDateRange.queryOptions(
+      { includeUserEvents: true, ...range },
+      {
+        staleTime: 30_000,
+        refetchOnWindowFocus: false,
+      },
+    ),
   );
 
   const updateRange = (range: CalendarRange) => {
     setRange({
-      startTime: new Date(range.startDate),
-      endTime: new Date(range.endDate),
+      dateStart: new Date(range.startDate),
+      dateEnd: new Date(range.endDate),
     });
   };
 

--- a/src/systems/events/calendar/calendars/RegisteredEventsCalendar.tsx
+++ b/src/systems/events/calendar/calendars/RegisteredEventsCalendar.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import EventCalendar from '../EventCalendar';
+import { useTRPC } from '@/trpc/react';
+import { CalendarRange } from '@/lib/utils/calendarRange';
+import { useState } from 'react';
+
+export default function RegisteredEventsCalendar() {
+  const api = useTRPC();
+
+  const [range, setRange] = useState<CalendarRange>(() => ({
+    startDate: new Date().toISOString(),
+    endDate: new Date().toISOString(),
+  }));
+
+  const { data: events = [], isFetching } = useQuery(
+    api.user.events.getRegisteredEventsByRange.queryOptions(range, {
+      staleTime: 30_000,
+      refetchOnWindowFocus: false,
+    }),
+  );
+
+  return (
+    <EventCalendar
+      events={events}
+      onMount={setRange}
+      onChange={setRange}
+      isFetching={isFetching}
+    />
+  );
+}

--- a/src/systems/events/calendar/calendars/RegisteredEventsCalendar.tsx
+++ b/src/systems/events/calendar/calendars/RegisteredEventsCalendar.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import EventCalendar from '../EventCalendar';
-import { useTRPC } from '@/trpc/react';
-import { CalendarRange } from '@/lib/utils/calendarRange';
 import { useState } from 'react';
+import { CalendarRange } from '@/lib/utils/calendarRange';
+import { useTRPC } from '@/trpc/react';
+import EventCalendar from '../EventCalendar';
 
 export default function RegisteredEventsCalendar() {
   const api = useTRPC();


### PR DESCRIPTION
Resolves #714 

Makes `/events/calendar` page show events from all clubs instead of just registered events, and no longer requires logging in