### PR TITLE
BetterAuth oAuth proxy

### DIFF
--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,5 +1,6 @@
 import { drizzleAdapter } from 'better-auth/adapters/drizzle';
 import { betterAuth } from 'better-auth/minimal';
+import { oAuthProxy } from 'better-auth/plugins';
 import { eq } from 'drizzle-orm';
 import { env } from '@/env.mjs';
 import { db } from './db';
@@ -113,5 +114,27 @@ export const auth = betterAuth({
     'https://clubs.utdnebula.com',
     'https://clubs-*-utdnebula.vercel.app',
     ...AUTH_TRUSTED_ORIGINS,
+  ],
+  plugins: [
+    ...((() => {
+      try {
+        const hostname = new URL(process.env.BETTER_AUTH_URL ?? '').hostname;
+        // Don't need proxy on production and localhost
+        return (
+          process.env.VERCEL_ENV !== 'production' && hostname !== 'localhost'
+        );
+      } catch (e) {
+        console.error(e);
+        return true;
+      }
+    })()
+      ? [
+          oAuthProxy({
+            // Use develop branch deployment as callback URL (for now)
+            productionURL: 'https://dev.clubs.utdnebula.com',
+            secret: process.env.OAUTH_PROXY_SECRET,
+          }),
+        ]
+      : []),
   ],
 });


### PR DESCRIPTION
Attempt to fix signing in with Google on Vercel preview deployments. Also would need to add `OAUTH_PROXY_SECRET` environment variable (already added to Vercel)

I used `dev.clubs.utdnebula.com` as the productionURL for now, if this feature works then we can use `clubs.utdnebula.com` as intended.

This needs to be in the develop branch to test it, so will merge this PR now and fingers crossed