### PR TITLE
BetterAuth oAuth proxy (part 2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,8 @@ DATABASE_URL=
 BETTER_AUTH_URL=
 # Generate using `openssl rand -base64 32`
 BETTER_AUTH_SECRET=
+# Connect to oAuth proxy on prod. Useful when port forwarding
+OAUTH_PROXY_SECRET=
 
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=

--- a/src/env.mjs
+++ b/src/env.mjs
@@ -19,6 +19,7 @@ const server = z.object({
     // VERCEL_URL doesn't include `https` so it cant be validated as a URL
     process.env.VERCEL ? z.string().min(1) : z.url(),
   ),
+  OAUTH_PROXY_SECRET: z.string().optional(),
   GOOGLE_CLIENT_ID: z.string().optional(),
   GOOGLE_CLIENT_SECRET: z.string().optional(),
   DISCORD_CLIENT_ID: z.string().optional(),
@@ -73,6 +74,7 @@ const processEnv = {
   DATABASE_URL: clean(process.env.DATABASE_URL),
   BETTER_AUTH_SECRET: clean(process.env.BETTER_AUTH_SECRET),
   BETTER_AUTH_URL: clean(process.env.BETTER_AUTH_URL),
+  OAUTH_PROXY_SECRET: clean(process.env.OAUTH_PROXY_SECRET),
   GOOGLE_CLIENT_ID: clean(process.env.GOOGLE_CLIENT_ID),
   GOOGLE_CLIENT_SECRET: clean(process.env.GOOGLE_CLIENT_SECRET),
   DISCORD_CLIENT_ID: clean(process.env.DISCORD_CLIENT_ID),

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -124,7 +124,7 @@ export const auth = betterAuth({
           process.env.VERCEL_ENV !== 'production' && hostname !== 'localhost'
         );
       } catch (e) {
-        console.error(e);
+        console.log(e);
         return true;
       }
     })()


### PR DESCRIPTION
Please also review #734 (had to merge to get this to work)

Fixes signing in with Google on Vercel preview deployments. Requires an `OAUTH_PROXY_SECRET` environment variable (already added to Vercel) Ideally, this also fixes signing in on port forwarding, but I still can't seem to get it to work so /shrug

I used `dev.clubs.utdnebula.com` as the productionURL for now, if this feature works then we can use `clubs.utdnebula.com` as intended.