### PR TITLE
Auto-detect supported platforms for Other contact links

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,6 +7,9 @@ const config: JestConfigWithTsJest = {
     '^.+\\.[tj]sx?$': [
       'ts-jest',
       {
+        tsconfig: {
+          rootDir: '.',
+        },
         useESM: true,
       },
     ],

--- a/src/systems/manage/forms/Contacts/Contacts.tsx
+++ b/src/systems/manage/forms/Contacts/Contacts.tsx
@@ -30,6 +30,7 @@ import type { SelectClub, SelectContact } from '@/server/db/models';
 import { contactNames, startContacts } from '@/server/db/schema/contacts';
 import { useTRPC } from '@/trpc/react';
 import ContactListItem from './ContactListItem';
+import { convertOtherContactPlatforms } from './contactPlatform';
 import { editClubContactSchema } from './schema';
 
 type FormData = z.infer<typeof editClubContactSchema>;
@@ -75,14 +76,20 @@ const Contacts = ({ club }: ContactsProps) => {
   const form = useAppForm({
     defaultValues,
     onSubmit: async ({ value, formApi }) => {
+      const contacts = convertOtherContactPlatforms(value.contacts);
+
       // Separate created vs modified
       const created: FormData['contacts'] = [];
       const modified: ContactWithId[] = [];
       const order: FormData['contacts'][number]['platform'][] = [];
+      const deleted = [...deletedIds];
 
       let hasReorder = false;
+      let hasPlatformConversion = false;
 
-      value.contacts.forEach((contact, index) => {
+      contacts.forEach((contact, index) => {
+        const submittedPlatform = value.contacts[index]?.platform;
+
         // Extra check for if user reorders, makes a change, then undoes reorder
         if (
           isReordered &&
@@ -92,6 +99,18 @@ const Contacts = ({ club }: ContactsProps) => {
         }
 
         order.push(contact.platform);
+
+        if (
+          submittedPlatform !== undefined &&
+          contact.platform !== submittedPlatform
+        ) {
+          hasPlatformConversion = true;
+          if (hasId(contact)) {
+            deleted.push(submittedPlatform);
+          }
+          created.push({ platform: contact.platform, url: contact.url });
+          return;
+        }
 
         // If it has no ID, it's created
         if (!hasId(contact)) {
@@ -109,10 +128,10 @@ const Contacts = ({ club }: ContactsProps) => {
 
       const updated = await editContacts.mutateAsync({
         clubId: club.id,
-        deleted: deletedIds,
+        deleted: [...new Set(deleted)],
         modified: modified,
         created: created,
-        order: hasReorder ? order : undefined,
+        order: hasReorder || hasPlatformConversion ? order : undefined,
       });
       setDeletedIds([]);
       setIsReordered(false);

--- a/src/systems/manage/forms/Contacts/contactPlatform.ts
+++ b/src/systems/manage/forms/Contacts/contactPlatform.ts
@@ -1,0 +1,65 @@
+import type { ContactSchema, Platforms } from '@/lib/utils/commonSchemas';
+
+const platformDomains = {
+  discord: ['discord.com', 'discord.gg', 'discordapp.com'],
+  instagram: ['instagram.com'],
+  twitter: ['twitter.com', 'x.com'],
+  facebook: ['facebook.com', 'fb.com', 'fb.me'],
+  youtube: ['youtube.com', 'youtu.be'],
+  twitch: ['twitch.tv'],
+  linkedIn: ['linkedin.com'],
+} as const satisfies Partial<Record<Platforms, readonly string[]>>;
+
+type DetectablePlatform = keyof typeof platformDomains | 'website';
+
+function matchesDomain(hostname: string, domain: string) {
+  return hostname === domain || hostname.endsWith(`.${domain}`);
+}
+
+export function detectContactPlatform(url: string): DetectablePlatform | null {
+  let protocol: string;
+  let hostname: string;
+
+  try {
+    const parsedUrl = new URL(url);
+    protocol = parsedUrl.protocol;
+    hostname = parsedUrl.hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+
+  for (const [platform, domains] of Object.entries(platformDomains) as [
+    keyof typeof platformDomains,
+    readonly string[],
+  ][]) {
+    if (domains.some((domain) => matchesDomain(hostname, domain))) {
+      return platform;
+    }
+  }
+
+  return protocol === 'http:' || protocol === 'https:' ? 'website' : null;
+}
+
+export function convertOtherContactPlatforms(
+  contacts: ContactSchema[],
+): ContactSchema[] {
+  const occupiedPlatforms = new Set(
+    contacts
+      .filter(({ platform }) => platform !== 'other')
+      .map(({ platform }) => platform),
+  );
+
+  return contacts.map((contact) => {
+    if (contact.platform !== 'other') {
+      return contact;
+    }
+
+    const detectedPlatform = detectContactPlatform(contact.url);
+    if (!detectedPlatform || occupiedPlatforms.has(detectedPlatform)) {
+      return contact;
+    }
+
+    occupiedPlatforms.add(detectedPlatform);
+    return { ...contact, platform: detectedPlatform };
+  });
+}

--- a/tests/contactPlatform.test.ts
+++ b/tests/contactPlatform.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from '@jest/globals';
+import type { ContactSchema } from '@/lib/utils/commonSchemas';
+import {
+  convertOtherContactPlatforms,
+  detectContactPlatform,
+} from '@/systems/manage/forms/Contacts/contactPlatform';
+
+describe('detectContactPlatform', () => {
+  test.each([
+    ['https://discord.gg/utd', 'discord'],
+    ['https://canary.discord.com/channels/1/2', 'discord'],
+    ['https://www.instagram.com/utdnebula/', 'instagram'],
+    ['https://x.com/utdnebula', 'twitter'],
+    ['https://mobile.twitter.com/utdnebula', 'twitter'],
+    ['https://www.facebook.com/utdnebula', 'facebook'],
+    ['https://youtu.be/example', 'youtube'],
+    ['https://music.youtube.com/channel/example', 'youtube'],
+    ['https://www.twitch.tv/utdnebula', 'twitch'],
+    ['https://www.linkedin.com/company/utdnebula', 'linkedIn'],
+  ])('detects %s as %s', (url, platform) => {
+    expect(detectContactPlatform(url)).toBe(platform);
+  });
+
+  test('does not treat a lookalike domain as a branded platform', () => {
+    expect(detectContactPlatform('https://notinstagram.com/utdnebula')).toBe(
+      'website',
+    );
+  });
+
+  test('does not detect an invalid URL', () => {
+    expect(detectContactPlatform('not a URL')).toBeNull();
+  });
+
+  test('uses Website as the fallback for a generic web URL', () => {
+    expect(
+      detectContactPlatform(
+        'https://example.com/?next=https://twitter.com/utdnebula',
+      ),
+    ).toBe('website');
+  });
+});
+
+describe('convertOtherContactPlatforms', () => {
+  test('converts an Other URL when its detected platform is unfilled', () => {
+    const contacts: ContactSchema[] = [
+      {
+        clubId: 'club-1',
+        platform: 'other',
+        url: 'https://instagram.com/utdnebula',
+      },
+    ];
+
+    expect(convertOtherContactPlatforms(contacts)).toEqual([
+      {
+        clubId: 'club-1',
+        platform: 'instagram',
+        url: 'https://instagram.com/utdnebula',
+      },
+    ]);
+    expect(contacts[0]?.platform).toBe('other');
+  });
+
+  test('keeps Other when the detected platform is already filled', () => {
+    const contacts: ContactSchema[] = [
+      {
+        platform: 'instagram',
+        url: 'https://instagram.com/existing',
+      },
+      {
+        platform: 'other',
+        url: 'https://instagram.com/utdnebula',
+      },
+    ];
+
+    expect(convertOtherContactPlatforms(contacts)).toEqual(contacts);
+  });
+
+  test('uses Website for a generic URL when Website is unfilled', () => {
+    const contacts: ContactSchema[] = [
+      { platform: 'other', url: 'https://example.com' },
+    ];
+
+    expect(convertOtherContactPlatforms(contacts)).toEqual([
+      { platform: 'website', url: 'https://example.com' },
+    ]);
+  });
+
+  test('keeps a generic URL as Other when Website is already filled', () => {
+    const contacts: ContactSchema[] = [
+      { platform: 'website', url: 'https://utdnebula.com' },
+      { platform: 'other', url: 'https://example.com' },
+    ];
+
+    expect(convertOtherContactPlatforms(contacts)).toEqual(contacts);
+  });
+
+  test('does not infer Email from a mailto URL', () => {
+    const contacts: ContactSchema[] = [
+      { platform: 'other', url: 'mailto:hello@example.com' },
+    ];
+
+    expect(convertOtherContactPlatforms(contacts)).toEqual(contacts);
+  });
+});


### PR DESCRIPTION
## Summary

- Detect supported contact platforms from URLs submitted as `Other`.
- Convert only into an unfilled platform, including `Website` as the HTTP(S) fallback, while leaving email detection disabled.
- Preserve existing contacts by replacing an existing `Other` row through the delete/create path when its database key changes.
- Keep contact ordering stable after a conversion.
- Add focused domain, lookalike-domain, occupied-platform, Website-fallback, and email-skip regression tests.

Closes #736

## Problem and user impact

Club managers can paste a Discord, Instagram, LinkedIn, or other recognized link into `Other`. That stores the wrong platform and gives the public listing a generic label/icon even when the matching platform slot is unused.

## Implementation

The new detector parses the URL hostname and matches exact domains or their subdomains. This avoids false positives such as `notinstagram.com` and query-string matches. A generic HTTP(S) URL falls back to `Website`; non-web schemes such as `mailto:` remain `Other`.

Before submission, `Other` entries are converted only if the inferred platform is not already present. Existing rows use `platform + clubId` as their key, so a converted stored row is deleted under `other` and recreated under the inferred platform. The submitted order uses the inferred key.

The Jest transform now sets an explicit `rootDir`, which TypeScript 6 requires in order to execute the new regression test (and the existing suite).

## Validation

- `npx jest tests/contactPlatform.test.ts --runInBand` — 18 tests passed
- `npm run lint:check`
- `npm run format:check`
- `SKIP_ENV_VALIDATION=1 npm run type:check`
- `SKIP_ENV_VALIDATION=1 npm run build` — application compilation and TypeScript passed; page-data collection then required the unavailable local `DATABASE_URL`
