### PR TITLE
perf: stabilize useIsMounted subscription

### DIFF
--- a/src/lib/utils/useIsMounted.ts
+++ b/src/lib/utils/useIsMounted.ts
@@ -1,5 +1,7 @@
 import { useSyncExternalStore } from 'react';
 
+const subscribe = () => () => {};
+
 /**
  * Hook to return whether the page is finished mounting on the client.
  * Use for conditional components and props instead of
@@ -11,7 +13,7 @@ import { useSyncExternalStore } from 'react';
  */
 export function useIsMounted(): boolean {
   const isMounted = useSyncExternalStore(
-    () => () => {},
+    subscribe,
     () => true,
     () => false,
   );


### PR DESCRIPTION
## Summary

- move the no-op subscription function to module scope
- keep its reference stable across renders so useSyncExternalStore does not resubscribe unnecessarily

## Validation

- Prettier check on src/lib/utils/useIsMounted.ts
- ESLint on src/lib/utils/useIsMounted.ts
- SKIP_ENV_VALIDATION=1 npm run type:check

Fixes #756