### PR TITLE
Fix unnecessary expansion controls on the officers card

### DIFF
--- a/src/systems/clubs/listing/panels/ClubOfficersCard/index.tsx
+++ b/src/systems/clubs/listing/panels/ClubOfficersCard/index.tsx
@@ -33,10 +33,11 @@ export default function ClubOfficersCard({
       const rightBottom = rightSide.getBoundingClientRect().bottom;
       const officerTop = officerContainer.getBoundingClientRect().top;
 
-      // The height of the officer card at start should be the distance between officer's top and the right side's bottom
-      const targetHeight = rightBottom - officerTop; // will be negative in mobile -> sets truncation to true, but maxHeight is default 300px
+      // Use the same minimum height for the collapsed size and overflow check,
+      // including when the right column ends above the officers card on mobile.
+      const targetHeight = Math.max(rightBottom - officerTop, 230);
       const contentHeight = contentRef.current.scrollHeight + 80; // height of the full officer card + padding/header space
-      setMaxHeight(Math.max(targetHeight, 230)); // at least 230px to show 2 officers
+      setMaxHeight(targetHeight);
       setNeedsTruncation(contentHeight > targetHeight && officers.length > 0); // if no officers, no truncation -- just show error text
     };
 


### PR DESCRIPTION
### Description

Resolves #740.

The officers card uses a minimum collapsed height of 230px, but previously decided whether to enable expansion using the unclamped distance to the bottom of the description/events column. When that column ends above or near the officers card, even a two-officer list gets a chevron and “See all officers” button.

Clamp the target height before using it for both the collapsed size and truncation check. This removes the unnecessary controls for the reported two-officer case while preserving the existing minimum height and behavior for longer lists. The existing content-height estimate is unchanged.

### Testing

- `npm run lint:check` — passed.
- `npm run format:check` — passed.
- `SKIP_ENV_VALIDATION=1 npm run type:check` — passed.
- `git diff --check` — passed.
- Browser verification using the actual component and shared Panel in a standalone local fixture:
  - Original code: two officers beside short content incorrectly show expansion controls.
  - Fixed code: two officers beside short content show no expansion controls.
  - Two officers in a stacked layout show no expansion controls.
  - Empty list displays “No officers listed” without expansion controls.
  - Three officers beside tall content show no expansion controls.
  - Eight officers beside short content retain expansion controls on desktop and in a stacked layout; “See all officers” switches to “Show less” when clicked.

The standalone fixture uses synthetic officers and layout dimensions. Full application verification against the Rocket League Club and ACM records was not run; that requires the application's configured services/database. The existing Jest suite writes to the database and was not run.

Suggested final manual check in the configured app: visit the two clubs linked in #740, then expand/collapse a longer officer list and resize between desktop and mobile.

### AI Disclosure

Codex inspected the issue and implementation, prepared this targeted fix, ran static checks and local browser verification, and drafted this PR description. SinhSinh reviewed the local preview and approved the change.

### Checklist

- [x] Create this PR
- [x] Perform final self-review
