### PR TITLE
Add senior engineers to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,33 @@
 # Clubs Project Lead or Head of Engineering should sign off on any PRs
 * @UTDNebula/clubs-lead @UTDNebula/head-of-engineering
 
-# Database migrations need to be checked by someone
-src/server/db/migrations/* @nl32
+# Senior engineers should review PRs that modify their systems
+# They may also be requested to review PRs for subfolders not covered by code owners
+
+## Both senior engineers should review PRs that modify the database or shared parts of codebase
+/src/server/db/ @ilutara @sy-pk
+/src/server/api/routers/user/ @ilutara @sy-pk
+
+## Public Features Team covers these systems: Clubs, Dashboard, Events
+/src/app/page.tsx @sy-pk
+/src/app/club-match/ @sy-pk
+/src/app/community/ @sy-pk
+/src/app/directory/ @sy-pk
+/src/app/events/ @sy-pk
+/src/server/api/routers/club/clubPublicRouter.ts @sy-pk
+/src/server/api/routers/event/eventPublicRouter.ts @sy-pk
+/src/systems/clubs/ @sy-pk
+/src/systems/dashboard/ @sy-pk
+/src/systems/events/ @sy-pk
+
+## Management Features Team covers these systems: Admin, Manage, Settings
+/src/app/admin/ @ilutara
+/src/app/get-started/ @ilutara
+/src/app/manage/ @ilutara
+/src/app/settings/ @ilutara
+/src/server/api/routers/admin/ @ilutara
+/src/server/api/routers/club/clubManageRouter.ts @ilutara
+/src/server/api/routers/event/eventManageRouter.ts @ilutara
+/src/systems/admin/ @ilutara
+/src/systems/manage/ @ilutara
+/src/systems/settings/ @ilutara


### PR DESCRIPTION
<!--
  Thank you for taking the time to contribute!
  We don't expect perfection and appreciate anything you can do to help.
  Please fill out each section below
-->

### Description
<!-- Include related issues or PRs (e.g., "Resolves #123") -->

Updates `CODEOWNERS` to include @Ilutara and @sy-pk (our senior engineers). Instead of forcing Laura and Cailyn to review every single PR, they're only get automatically review requested for PRs that modify code belonging to their system. If needed, I can always just request a review from them on a PR.

I don't know Roua's GitHub username :sob: but tbf I'm not sure what stuff necessarily belongs to the design team anyways

### Testing
<!-- How have you tested the changes in this PR? How can we test it? -->

Uhhh hopefully my syntax is correct? Check [CODEOWNERS docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)

### AI Disclosure
<!-- In general, how did you use AI to help you? (see our AI policy at https://nebula-labs.atlassian.net/wiki/x/AgCwQw) -->

None

### Checklist
<!-- Please check off that you've completed each item below -->

- [x] Create this PR
- [x] Perform final self-review
